### PR TITLE
Add RDP session detection to block hardware token signing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyship"
-version = "0.7.1"
+version = "0.7.2"
 description = "freezer, installer and updater for Python applications"
 readme = "readme.md"
 license = "MIT"

--- a/pyship/__init__.py
+++ b/pyship/__init__.py
@@ -18,7 +18,7 @@ from .app_info import AppInfo, get_app_info, get_app_info_py_project
 from .get_icon import get_icon
 from .nsis import run_nsis
 from .download import file_download, extract, PyshipDownloadError
-from .signing import sign_if_configured, sign_file_token, is_token_present, is_certificate_in_store, check_signing_available
+from .signing import sign_if_configured, sign_file_token, is_token_present, is_certificate_in_store, is_rdp_session, check_signing_available
 from .msix import create_msix
 from .create_launcher import create_pyship_launcher
 from .clip import create_base_clip, install_target_app, create_clip, create_clip_file

--- a/pyship/pyship.py
+++ b/pyship/pyship.py
@@ -18,7 +18,7 @@ from pyship import __application_name__ as pyship_application_name
 from pyship import __author__ as pyship_author
 from pyship import __version__ as pyship_version
 from pyship import run_nsis, create_clip, create_pyship_launcher, pyship_print, APP_DIR_NAME, create_clip_file, get_app_info, PyShipCloud
-from pyship.signing import sign_if_configured, check_signing_available
+from pyship.signing import sign_if_configured, check_signing_available, is_rdp_session
 from pyship.msix import create_msix
 from pyship import PyshipNoAppName
 from pyship.exceptions import PyshipSigningUnavailable
@@ -147,6 +147,14 @@ class PyShip:
 
         # Pre-flight signing check
         if self.code_sign:
+            token_mode = self.certificate_sha1 is not None or self.certificate_subject is not None or self.certificate_auto_select
+            if token_mode and is_rdp_session():
+                pyship_print(
+                    "RDP session detected - hardware token signing is not supported over Remote Desktop. "
+                    "Token PIN entry does not work over RDP, and failed attempts may lock your token. "
+                    "Please sign from a local console session."
+                )
+                return None
             available = check_signing_available(
                 pfx_path=self.pfx_path,
                 certificate_sha1=self.certificate_sha1,

--- a/pyship/signing.py
+++ b/pyship/signing.py
@@ -13,8 +13,12 @@ smart-card hardware, certificate store entry) is available before signing begins
 import hashlib
 import ssl
 import subprocess
+import sys
 from pathlib import Path
 from typing import Union
+
+if sys.platform == "win32":
+    import ctypes
 
 from typeguard import typechecked
 from balsa import get_logger
@@ -143,6 +147,46 @@ def is_token_present() -> bool:
 
 
 @typechecked
+def is_rdp_session() -> bool:
+    """
+    Detect if the current session is a Remote Desktop (RDP) session.
+
+    Hardware token PIN dialogs do not work over RDP, and failed attempts
+    count against the token lockout counter.
+
+    Uses ``GetSystemMetrics(SM_REMOTESESSION)`` as primary detection,
+    with ``query session`` command as fallback.
+
+    :return: True if the session appears to be an RDP/remote session
+    """
+    # Primary: Win32 API
+    try:
+        SM_REMOTESESSION = 0x1000
+        if ctypes.windll.user32.GetSystemMetrics(SM_REMOTESESSION) != 0:
+            log.debug("RDP session detected via GetSystemMetrics(SM_REMOTESESSION)")
+            return True
+    except (AttributeError, NameError, OSError) as exc:
+        log.debug(f"GetSystemMetrics check failed: {exc}")
+
+    # Fallback: parse 'query session' output
+    try:
+        result = subprocess.run(["query", "session"], capture_output=True, text=True, timeout=10)
+        if result.stdout:
+            for line in result.stdout.splitlines():
+                # Active session line starts with '>'
+                if line.strip().startswith(">"):
+                    session_name = line.strip().lstrip(">").split()[0].lower()
+                    if session_name.startswith("rdp-"):
+                        log.debug(f"RDP session detected via query session: {session_name}")
+                        return True
+    except Exception as exc:
+        log.debug(f"query session check failed: {exc}")
+
+    log.debug("no RDP session detected")
+    return False
+
+
+@typechecked
 def is_certificate_in_store(certificate_sha1: Union[str, None] = None, certificate_subject: Union[str, None] = None) -> bool:
     """
     Check if a signing certificate is present in the Windows Certificate Store (MY).
@@ -217,6 +261,14 @@ def check_signing_available(
 
     token_mode = certificate_sha1 is not None or certificate_subject is not None or certificate_auto_select
     if not token_mode:
+        return False
+
+    if is_rdp_session():
+        pyship_print(
+            "RDP session detected - hardware token signing is not supported over Remote Desktop. "
+            "Token PIN entry does not work over RDP, and failed attempts may lock your token. "
+            "Please sign from a local console session."
+        )
         return False
 
     if not is_token_present():

--- a/test_pyship/test_b_signing.py
+++ b/test_pyship/test_b_signing.py
@@ -13,6 +13,7 @@ from pyship.signing import (
     _validate_sha1,
     check_signing_available,
     is_certificate_in_store,
+    is_rdp_session,
     is_token_present,
     sign_file,
     sign_file_token,
@@ -304,27 +305,90 @@ def test_check_signing_available_pfx_missing(tmp_path):
 
 
 def test_check_signing_available_token_mode_both_checks_pass():
-    with patch("pyship.signing.is_token_present", return_value=True), patch("pyship.signing.is_certificate_in_store", return_value=True):
+    with patch("pyship.signing.is_rdp_session", return_value=False), patch("pyship.signing.is_token_present", return_value=True), patch("pyship.signing.is_certificate_in_store", return_value=True):
         assert check_signing_available(certificate_sha1=VALID_SHA1) is True
 
 
 def test_check_signing_available_token_not_present():
-    with patch("pyship.signing.is_token_present", return_value=False):
+    with patch("pyship.signing.is_rdp_session", return_value=False), patch("pyship.signing.is_token_present", return_value=False):
         assert check_signing_available(certificate_sha1=VALID_SHA1) is False
 
 
 def test_check_signing_available_token_present_cert_missing():
-    with patch("pyship.signing.is_token_present", return_value=True), patch("pyship.signing.is_certificate_in_store", return_value=False):
+    with patch("pyship.signing.is_rdp_session", return_value=False), patch("pyship.signing.is_token_present", return_value=True), patch("pyship.signing.is_certificate_in_store", return_value=False):
         assert check_signing_available(certificate_sha1=VALID_SHA1) is False
 
 
 def test_check_signing_available_auto_select_token_present():
-    with patch("pyship.signing.is_token_present", return_value=True):
+    with patch("pyship.signing.is_rdp_session", return_value=False), patch("pyship.signing.is_token_present", return_value=True):
         assert check_signing_available(certificate_auto_select=True) is True
 
 
 def test_check_signing_available_nothing_configured():
     assert check_signing_available() is False
+
+
+# ---------------------------------------------------------------------------
+# is_rdp_session
+# ---------------------------------------------------------------------------
+
+
+def test_is_rdp_session_true_via_get_system_metrics():
+    """GetSystemMetrics returning nonzero indicates RDP."""
+    with patch("pyship.signing.ctypes") as mock_ctypes:
+        mock_ctypes.windll.user32.GetSystemMetrics.return_value = 1
+        assert is_rdp_session() is True
+
+
+def test_is_rdp_session_false_via_get_system_metrics():
+    """GetSystemMetrics returning 0 indicates local console."""
+    with patch("pyship.signing.ctypes") as mock_ctypes:
+        mock_ctypes.windll.user32.GetSystemMetrics.return_value = 0
+        mock_result = MagicMock()
+        mock_result.stdout = ">console            User                 1  Active\n"
+        with patch("pyship.signing.subprocess.run", return_value=mock_result):
+            assert is_rdp_session() is False
+
+
+def test_is_rdp_session_fallback_to_query_session():
+    """When GetSystemMetrics fails, falls back to query session."""
+    with patch("pyship.signing.ctypes") as mock_ctypes:
+        mock_ctypes.windll.user32.GetSystemMetrics.side_effect = AttributeError("no windll")
+        mock_result = MagicMock()
+        mock_result.stdout = ">rdp-tcp#0          User                 1  Active\n"
+        with patch("pyship.signing.subprocess.run", return_value=mock_result):
+            assert is_rdp_session() is True
+
+
+def test_is_rdp_session_false_when_all_checks_fail():
+    """When both checks fail, returns False (fail-open)."""
+    with patch("pyship.signing.ctypes") as mock_ctypes:
+        mock_ctypes.windll.user32.GetSystemMetrics.side_effect = AttributeError("no windll")
+        with patch("pyship.signing.subprocess.run", side_effect=FileNotFoundError("not found")):
+            assert is_rdp_session() is False
+
+
+# ---------------------------------------------------------------------------
+# check_signing_available — RDP blocking (token mode only)
+# ---------------------------------------------------------------------------
+
+
+def test_check_signing_available_token_blocked_by_rdp():
+    """Token mode should be blocked when RDP session is detected."""
+    with patch("pyship.signing.is_rdp_session", return_value=True):
+        assert check_signing_available(certificate_sha1=VALID_SHA1) is False
+
+
+def test_check_signing_available_pfx_not_blocked_by_rdp(pfx_file):
+    """PFX mode should NOT be blocked by RDP — PFX signing works fine over RDP."""
+    with patch("pyship.signing.is_rdp_session", return_value=True):
+        assert check_signing_available(pfx_path=pfx_file) is True
+
+
+def test_check_signing_available_token_allowed_when_not_rdp():
+    """Token mode proceeds normally when not in RDP."""
+    with patch("pyship.signing.is_rdp_session", return_value=False), patch("pyship.signing.is_token_present", return_value=True), patch("pyship.signing.is_certificate_in_store", return_value=True):
+        assert check_signing_available(certificate_sha1=VALID_SHA1) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Detect RDP sessions via `GetSystemMetrics(SM_REMOTESESSION)` (primary) with `query session` command parsing as fallback
- When RDP is detected and hardware token signing is configured, exit early with a clear message instead of attempting to sign (which would fail and risk locking the token)
- PFX-based signing is unaffected — only hardware token mode is blocked over RDP
- Bump version to 0.7.2

## Test plan
- [x] 7 new tests for `is_rdp_session()` and `check_signing_available()` RDP integration
- [x] All 252 existing tests pass
- [x] Live verification: `is_rdp_session()` returns `True` over RDP, confirmed on current session

🤖 Generated with [Claude Code](https://claude.com/claude-code)