### PR TITLE
Exclude .clip from NSIS installer, normalize LICENSE to CRLF, fail CLI when no installer produced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,5 +96,5 @@ venv\Scripts\python.exe -m pytest test_pyship/ -v
 ## Important Notes
 
 - Windows-only currently. Paths and scripts assume Windows.
-- The `pyshipupdate` package is a sibling project (not on PyPI); its wheel is expected at `../pyshipupdate/dist/` for local development.
+- The `pyshipupdate` package is a sibling project, published on PyPI (0.2.3); for local development its wheel can also be installed from `../pyshipupdate/dist/`.
 - CLIP uses a standalone Python (from python-build-standalone via uv) so `python.exe` is at `<clip_dir>/python.exe`.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ file (typical for AWS CLI and boto3). These are not in `pyproject.toml` since it
 | `-i`, `--id`     | AWS Access Key ID     |
 | `-s`, `--secret` | AWS Secret Access Key |
 
+## Build Outputs
+
+A `ship()` run produces:
+
+- `installers/{app_name}_installer_win.exe` — the NSIS installer for direct distribution.
+- `{app_name}_{version}.clip` — the zipped CLIP that pyshipupdate downloads for background updates. It is only
+  created when uploading to S3, and it is never packed into the NSIS installer (which would roughly double the
+  installer's size).
+
+If your project has a `LICENSE` file, it is displayed on the installer's license page. pyship normalizes the file's
+line endings to CRLF in a build-tree copy automatically (NSIS requires DOS-format text files), so the file in your
+repository can stay LF-only.
+
+The `pyship` command exits with status 1 if no installer was produced (for example, when code signing is blocked
+because the build is running over an RDP session), so build scripts fail loudly instead of appearing to succeed.
+
 ## Microsoft Windows Code Signing (Optional)
 
 Signing your executables suppresses the Windows SmartScreen "Unknown Publisher" warning. pyship signs two files: the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyship"
-version = "0.7.2"
+version = "0.7.3"
 description = "freezer, installer and updater for Python applications"
 readme = "readme.md"
 license = "MIT"

--- a/pyship/main.py
+++ b/pyship/main.py
@@ -5,11 +5,13 @@ Reads configuration from ``[tool.pyship]`` in the current directory's
 ``pyproject.toml``, applies CLI argument overrides, then runs :meth:`PyShip.ship`.
 """
 
+import sys
 from pathlib import Path
 
 import toml
 
 from pyship import PyShip, __application_name__, __author__, PyshipLog, get_arguments, pyship_print
+from pyship.ci import is_ci
 
 #: pyproject.toml keys (under ``[tool.pyship]``) that map directly to PyShip attributes.
 #: Keys whose PyShip attribute name differs use ``(toml_key, attr_name)`` tuples.
@@ -82,4 +84,8 @@ def main():
         pyship.certificate_auto_select = True
     if args.code_sign:
         pyship.code_sign = True
-    pyship.ship()
+    installer_path = pyship.ship()
+    if installer_path is None and not is_ci():
+        # No installer produced (e.g. RDP session blocked signing) - fail so build
+        # scripts notice. In CI, run_nsis legitimately returns None when NSIS is absent.
+        sys.exit(1)

--- a/pyship/nsis.py
+++ b/pyship/nsis.py
@@ -50,6 +50,14 @@ def run_nsis(target_app_info: AppInfo, target_app_version: VersionInfo, app_dir:
     license_file_name = "LICENSE"
 
     if Path(target_app_info.project_dir, license_file_name).exists():
+        # NSIS LicenseData requires DOS (\r\n) line endings for .txt content - an LF-only file
+        # renders as one long unbroken line. Normalize a copy into the build tree (app_dir's
+        # parent, outside the "File /r" payload) rather than requiring target repos to commit CRLF.
+        license_text = Path(target_app_info.project_dir, license_file_name).read_text()
+        normalized_license_path = Path(app_dir.parent, license_file_name).absolute()
+        with open(normalized_license_path, "w", newline="\r\n") as normalized_license_file:
+            normalized_license_file.write(license_text)
+
         nsis_file_path = Path(target_app_info.project_dir, f"{target_app_info.name}.nsi").absolute()
         pyship_print(f'building installer "{nsis_file_path}" ("{nsis_file_path.absolute()}")')
 
@@ -93,11 +101,11 @@ def run_nsis(target_app_info: AppInfo, target_app_version: VersionInfo, app_dir:
         nsis_lines.append("")
         nsis_lines.append(r'InstallDir "$PROGRAMFILES\${COMPANYNAME}\${APPNAME}"')
         nsis_lines.append("")
-        nsis_lines.append(r"# rtf or txt file - remember if it is txt, it must be in the DOS text format (\r\n)")
-        nsis_lines.append('LicenseData "LICENSE"')
+        nsis_lines.append(r"# rtf or txt file - txt must be in the DOS text format (\r\n); this is a normalized copy")
+        nsis_lines.append(f'LicenseData "{normalized_license_path}"')
         nsis_lines.append(r"# This will be in the installer/uninstaller's title bar")
         nsis_lines.append('Name "${COMPANYNAME} - ${APPNAME}"')
-        nsis_lines.append(f"Icon {icon_path}")
+        nsis_lines.append(f'Icon "{icon_path}"')
         nsis_lines.append(f'outFile "{installer_exe_path}"')
         nsis_lines.append("SetCompressor LZMA")
         nsis_lines.append("")
@@ -129,7 +137,8 @@ def run_nsis(target_app_info: AppInfo, target_app_version: VersionInfo, app_dir:
         nsis_lines.append("  # Files for the install directory - to build the installer, these should be in the same directory as the install script (this file)")
         nsis_lines.append("  setOutPath $INSTDIR")
         nsis_lines.append('  # Files added here should be removed by the uninstaller (see section "uninstall")')
-        nsis_lines.append(f"  File /r {app_dir}\\*")
+        # /x *.clip: the zipped CLIP update payload must never ship inside the installer
+        nsis_lines.append(f'  File /r /x "*.clip" "{app_dir}\\*"')
 
         nsis_lines.append("")
         nsis_lines.append('  # Uninstaller - See function un.onInit and section "uninstall" for configuration')

--- a/pyship/pyship.py
+++ b/pyship/pyship.py
@@ -179,7 +179,6 @@ class PyShip:
 
             clip_dir = create_clip(target_app_info, app_dir, Path(self.project_dir, self.dist_dir), cache_dir, python_version=self.python_version)
 
-            clip_file_path = create_clip_file(clip_dir)
             assert isinstance(target_app_info.version, VersionInfo)
             installer_exe_path = run_nsis(target_app_info, target_app_info.version, app_dir)
             if installer_exe_path is not None and self.code_sign:
@@ -217,6 +216,10 @@ class PyShip:
                         installer_url = self.cloud_access.upload(installer_exe_path)
                         pyship_print(f'uploaded "{installer_exe_path}" to {installer_url}')
 
+                        # The .clip (zipped CLIP update payload) is only needed for upload, so it is
+                        # created here rather than unconditionally — it would otherwise sit inside
+                        # app_dir and get packed into the NSIS installer, doubling its size.
+                        clip_file_path = create_clip_file(clip_dir)
                         clip_url = self.cloud_access.upload(clip_file_path)
                         pyship_print(f'uploaded "{clip_file_path}" to {clip_url}')
 


### PR DESCRIPTION
## Summary
- Create the `.clip` update payload only when uploading to S3, and exclude `*.clip` from the NSIS `File /r` payload so the zipped CLIP no longer roughly doubles the installer size.
- Normalize the project `LICENSE` file to CRLF line endings in a build-tree copy before passing it to NSIS `LicenseData` (NSIS requires DOS text format; LF-only files rendered as one unbroken line). Also quote the icon and license paths in the generated .nsi script.
- The `pyship` CLI now exits with status 1 when `ship()` produces no installer (e.g. hardware-token signing blocked over an RDP session), so build scripts fail loudly. In CI, `run_nsis` legitimately returns `None` when NSIS is absent, so CI is exempt.
- README: new "Build Outputs" section documenting the installer, the `.clip` payload behavior, LICENSE normalization, and the CLI exit code.

## Test plan
- [ ] CI test suite passes
- [ ] Local `ship()` run: installer no longer contains the `.clip` file; installer size reduced
- [ ] Installer license page renders LICENSE with proper line breaks from an LF-only repo file

🤖 Generated with [Claude Code](https://claude.com/claude-code)