### PR TITLE
Add run_claude.bat to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ doc/flake8_report.txt
 nul
 settings.local.json
 uv.lock
+run_claude.bat


### PR DESCRIPTION
## Summary
- Ignore `run_claude.bat`, a local developer launcher script that should not be committed to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)