### PR TITLE
Abort PyPI upload when the wheel build fails

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,9 @@ rmdir /S /Q dist
 rmdir /S /Q build
 call venv\scripts\activate.bat
 python -m build --wheel
-deactivate
+if errorlevel 1 (
+    echo build failed
+    call deactivate
+    exit /b 1
+)
+call deactivate

--- a/scripts/pypi.bat
+++ b/scripts/pypi.bat
@@ -1,7 +1,23 @@
 pushd .
 cd ..
 call build.bat
+if errorlevel 1 (
+    echo build failed - aborting PyPI upload
+    popd
+    exit /b 1
+)
+if not exist dist\*.whl (
+    echo no wheel in dist - aborting PyPI upload
+    popd
+    exit /b 1
+)
 call venv\scripts\activate.bat
 call twine upload dist\*
+if errorlevel 1 (
+    echo twine upload failed
+    call deactivate
+    popd
+    exit /b 1
+)
 call deactivate
 popd


### PR DESCRIPTION
## Summary
- `build.bat` ended with `deactivate`, which masked a failed `python -m build` exit code; it now exits with status 1 when the build fails.
- `scripts/pypi.bat` uploaded `dist\*` unconditionally, so a failed build silently published whatever stale wheel was left in `dist/` (this is how an outdated 0.7.1 wheel reached PyPI on 2026-07-19). It now aborts if the build fails or `dist/` contains no wheel, and propagates twine upload failures.

## Test plan
- [ ] CI passes (scripts are not exercised by CI; changes are errorlevel guards only)
- [ ] `build.bat` from repo root still builds the wheel
- [ ] `scripts\pypi.bat` aborts before upload when the build step fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)