### PR TITLE
DRY refactor: shared SDK tool discovery and installer naming, full docstring coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ pyship/              # Main package
   create_launcher.py # Compiles C# stub and copies standalone launcher script
   launcher_stub.py   # C# source template and csc.exe compilation
   nsis.py            # NSIS installer script generation
+  msix.py            # MSIX package creation (Microsoft Store / sideloading)
+  signing.py         # Code signing via signtool.exe (PFX and hardware token)
+  installer.py       # Shared installer naming ({app}_installer_{os}.{ext}, installers/ dir)
+  windows_sdk.py     # Windows SDK tool discovery (signtool.exe, makeappx.exe)
   cloud.py           # AWS S3 upload
   download.py        # File download with caching and safe extraction
 test_pyship/         # Tests (alphabetically ordered: test_a_, test_b_, etc.)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ file (typical for AWS CLI and boto3). These are not in `pyproject.toml` since it
 
 A `ship()` run produces:
 
-- `installers/{app_name}_installer_win.exe` — the NSIS installer for direct distribution.
+- `installers/{app_name}_installer_win64.exe` — the NSIS installer for direct distribution. The platform suffix
+  (`win64` on 64-bit Windows) identifies the target OS and architecture, and is the same for all installer types.
 - `{app_name}_{version}.clip` — the zipped CLIP that pyshipupdate downloads for background updates. It is only
   created when uploading to S3, and it is never packed into the NSIS installer (which would roughly double the
   installer's size).
@@ -368,8 +369,8 @@ ps.ship()
 
 This produces two files in `installers/`:
 
-- `{app_name}_installer_win.exe` — the NSIS installer (direct distribution, auto-updates via pyshipupdate)
-- `{app_name}_installer_win.msix` — the MSIX package (Store or sideloading, updates managed by the Store)
+- `{app_name}_installer_win64.exe` — the NSIS installer (direct distribution, auto-updates via pyshipupdate)
+- `{app_name}_installer_win64.msix` — the MSIX package (Store or sideloading, updates managed by the Store)
 
 Both are signed with the same certificate. The NSIS installer is built first; the MSIX is packed from the same app
 directory afterwards, so they do not interfere with each other.
@@ -425,7 +426,7 @@ ps = PyShip(
 Signed MSIX packages can be installed directly without going through the Store — double-click the `.msix` file or use:
 
 ```batch
-Add-AppxPackage -Path "{app_name}_installer_win.msix"
+Add-AppxPackage -Path "{app_name}_installer_win64.msix"
 ```
 
 This is useful for enterprise deployments and beta distribution.

--- a/pyship/__init__.py
+++ b/pyship/__init__.py
@@ -8,6 +8,8 @@ SUPPORTED_PYTHON_VERSIONS = ("3.11", "3.12", "3.13", "3.14")
 
 from .path import NullPath
 from .__version__ import __version__, __author__, __application_name__, __title__, __description__, __url__, __author_email__, __download_url__
+from .windows_sdk import find_sdk_tool, WINDOWS_SDK_BIN_DIR
+from .installer import INSTALLERS_DIR_NAME, installer_file_name, get_installers_dir
 from .logging import PyshipLog, log_process_output
 from .exceptions import PyshipException, PyshipNoProductDirectory, PyshipCouldNotGetVersion, PyshipLicenseFileDoesNotExist, PyshipInsufficientAppInfo, PyshipNoAppName
 from .exceptions import PyshipNoTargetAppInfo, PyshipSigningUnavailable
@@ -18,7 +20,7 @@ from .app_info import AppInfo, get_app_info, get_app_info_py_project
 from .get_icon import get_icon
 from .nsis import run_nsis
 from .download import file_download, extract, PyshipDownloadError
-from .signing import sign_if_configured, sign_file_token, is_token_present, is_certificate_in_store, is_rdp_session, check_signing_available
+from .signing import sign_if_configured, sign_file_token, is_token_present, is_certificate_in_store, is_rdp_session, check_signing_available, is_token_signing_configured
 from .msix import create_msix
 from .create_launcher import create_pyship_launcher
 from .clip import create_base_clip, install_target_app, create_clip, create_clip_file

--- a/pyship/app_info.py
+++ b/pyship/app_info.py
@@ -1,3 +1,11 @@
+"""
+Target application metadata.
+
+:class:`AppInfo` holds everything pyship needs to know about the target app.
+It is populated from the target's ``pyproject.toml`` (``[project]`` and
+``[tool.pyship]`` sections) and from the built wheel's metadata.
+"""
+
 import re
 from pathlib import Path
 from dataclasses import dataclass
@@ -40,6 +48,13 @@ def _pep440_to_semver(version_str: str) -> str:
 
 @dataclass
 class AppInfo:
+    """
+    Metadata describing the target application being shipped.
+
+    Fields are filled in progressively: first from ``pyproject.toml``, then from
+    the built wheel's metadata (see :func:`get_app_info`).
+    """
+
     name: Union[str, None] = None
     author: Union[str, None] = None
     version: Union[VersionInfo, None] = None
@@ -56,6 +71,11 @@ class AppInfo:
     icon_file_name: Union[str, None] = None
 
     def setup_paths(self, target_app_project_dir: Path):
+        """
+        Derive project-relative paths (venv python, installed pyship package dir) from the project dir.
+
+        :param target_app_project_dir: target application project directory
+        """
         self.project_dir = target_app_project_dir
         self.python_exe_path = Path(self.project_dir, "venv", "Scripts", "python.exe")
         self.pyship_installed_package_dir = Path(self.project_dir, "venv", "Lib", "site-packages", pyship_application_name)
@@ -63,7 +83,17 @@ class AppInfo:
 
 @typechecked
 def get_app_info_py_project(app_info: AppInfo, target_app_project_dir: Path) -> AppInfo:
+    """
+    Fill in app info from the target project's ``pyproject.toml``.
 
+    Reads the ``[project]`` section (PEP 621, with flit legacy fallback for the
+    name) and the ``[tool.pyship]`` section (``ui``, ``run_on_startup``, and the
+    deprecated ``is_gui``). Returns a copy; the input is not mutated.
+
+    :param app_info: app info gathered so far
+    :param target_app_project_dir: directory containing pyproject.toml
+    :return: a new AppInfo with pyproject.toml values applied
+    """
     app_info = deepcopy(app_info)
     pyproject_toml_file_name = "pyproject.toml"
     pyproject_toml_file_path = Path(target_app_project_dir, pyproject_toml_file_name)
@@ -114,6 +144,13 @@ def get_app_info_py_project(app_info: AppInfo, target_app_project_dir: Path) -> 
 
 @typechecked
 def get_app_info_wheel(app_info: AppInfo, dist_path: Path) -> AppInfo:
+    """
+    Fill in app info from a built wheel's metadata (name, version, author, description).
+
+    :param app_info: app info gathered so far (mutated and returned)
+    :param dist_path: path to the .whl file to inspect
+    :return: the AppInfo with wheel metadata applied
+    """
     if dist_path.exists():
         wheel_info = inspect_wheel(dist_path)
         metadata = wheel_info["dist_info"]["metadata"]

--- a/pyship/arguments.py
+++ b/pyship/arguments.py
@@ -1,3 +1,7 @@
+"""
+Command-line argument definitions for the pyship CLI.
+"""
+
 import sys
 import argparse
 from typing import Any
@@ -8,6 +12,11 @@ from pyship import __name__, __version__
 
 
 def get_arguments() -> Any:
+    """
+    Parse pyship CLI arguments (cloud credentials, upload flags, code signing, logging).
+
+    :return: parsed argparse namespace (exits after printing version if --version given)
+    """
     parser = argparse.ArgumentParser(prog=__name__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument("-p", "--profile", help="cloud profile")

--- a/pyship/ci.py
+++ b/pyship/ci.py
@@ -1,3 +1,7 @@
+"""
+CI environment detection.
+"""
+
 import os
 
 

--- a/pyship/clip.py
+++ b/pyship/clip.py
@@ -1,3 +1,11 @@
+"""
+CLIP (Complete Location Independent Python) environment creation.
+
+A CLIP is a standalone, relocatable directory holding a full Python
+environment (standalone Python from python-build-standalone via uv) plus the
+target application and all of its dependencies.
+"""
+
 import platform
 import shutil
 from pathlib import Path
@@ -33,9 +41,10 @@ def create_clip(target_app_info: AppInfo, app_dir: Path, target_app_package_dist
 
 def create_clip_file(clip_dir: Path) -> Path:
     """
-    create clip file (the zipped update for the target application) from clip dir
-    :param clip_dir:
-    :return: path to the clip file
+    Zip a CLIP directory into a ``.clip`` file (the update payload downloaded by pyshipupdate).
+
+    :param clip_dir: CLIP directory to archive
+    :return: path to the created .clip file (next to the CLIP directory)
     """
     clip_dir_string = str(clip_dir)
     archive_path = Path(shutil.make_archive(clip_dir_string, "zip", clip_dir_string))  # create a "zip" file of the clip dir

--- a/pyship/cloud.py
+++ b/pyship/cloud.py
@@ -1,3 +1,7 @@
+"""
+AWS S3 upload/download of shipped artifacts (installer and .clip files).
+"""
+
 from pathlib import Path
 
 from typeguard import typechecked
@@ -38,4 +42,8 @@ class PyShipCloud:
 
     @typechecked
     def download(self, file_path: Path):
+        """
+        download a file from S3 (cached), keyed by the file's name
+        :param file_path: destination path; its name is used as the S3 key
+        """
         self.s3_access.download_cached(file_path.name, file_path)

--- a/pyship/create_launcher.py
+++ b/pyship/create_launcher.py
@@ -1,3 +1,11 @@
+"""
+Launcher creation.
+
+The launcher is what end users run: a compiled C# stub ``{app}.exe`` that finds
+the newest CLIP and runs the standalone Python launcher script, plus a
+diagnostic ``.bat`` (console output always visible) and the app icon.
+"""
+
 import shutil
 from pathlib import Path
 from typing import Union

--- a/pyship/custom_print.py
+++ b/pyship/custom_print.py
@@ -1,3 +1,8 @@
+"""
+User-facing output: :func:`pyship_print` combines logging with a timestamped
+console print (or a tkinter label in GUI mode).
+"""
+
 from tkinter import Tk, Label
 from datetime import datetime
 
@@ -14,6 +19,13 @@ window.withdraw()  # no main window
 
 @typechecked
 def pyship_print(s: str, ui: str = "cli"):
+    """
+    Emit a user-facing message: always logged, and shown on the console
+    (timestamped) or in a GUI window depending on *ui*.
+
+    :param s: message to display
+    :param ui: "cli" (default) for console output, "gui" for a tkinter window
+    """
     log.info(s)
     if ui == "gui":
         label = Label(window, text=s)  # adds to the window each time

--- a/pyship/download.py
+++ b/pyship/download.py
@@ -1,3 +1,8 @@
+"""
+File download with caching, and safe archive extraction (guards against
+path-traversal entries in zip/tar archives).
+"""
+
 import shutil
 import sys
 import tarfile

--- a/pyship/exceptions.py
+++ b/pyship/exceptions.py
@@ -1,41 +1,61 @@
+"""
+pyship exception hierarchy. All pyship exceptions derive from :class:`PyshipException`.
+"""
+
 from pathlib import Path
 from typing import Tuple
 
 
 class PyshipException(Exception):
+    """Base class for all pyship exceptions."""
+
     pass
 
 
 class PyshipNoProductDirectory(PyshipException):
+    """The expected product directory does not exist."""
+
     def __init__(self, path: Path):
         super().__init__(self.__class__.__name__, str(path))
 
 
 class PyshipCouldNotGetVersion(PyshipException):
+    """A usable version could not be determined."""
+
     def __init__(self, python_ver_tuple: Tuple):
         super().__init__(self.__class__.__name__, python_ver_tuple)
 
 
 class PyshipNoAppName(PyshipException):
+    """The target application name could not be determined (e.g. missing from pyproject.toml)."""
+
     def __init__(self):
         super().__init__(self.__class__.__name__)
 
 
 class PyshipNoTargetAppInfo(PyshipException):
+    """No target application info could be gathered."""
+
     def __init__(self):
         super().__init__(self.__class__.__name__)
 
 
 class PyshipLicenseFileDoesNotExist(PyshipException):
+    """The target project has no LICENSE file (required for the NSIS installer's license page)."""
+
     def __init__(self, path: Path):
         super().__init__(self.__class__.__name__, path)
 
 
 class PyshipInsufficientAppInfo(PyshipException):
+    """Required app info fields (name, author, version) are missing or invalid."""
+
     def __init__(self):
         super().__init__(self.__class__.__name__)
 
 
 class PyshipSigningUnavailable(PyshipException):
+    """code_sign is enabled but signing infrastructure is missing or a file failed to sign."""
+
     def __init__(self, message: str = ""):
         super().__init__(self.__class__.__name__, message)

--- a/pyship/get_icon.py
+++ b/pyship/get_icon.py
@@ -1,3 +1,8 @@
+"""
+Application icon discovery: prefer the target app's own .ico (searched in
+several conventional locations), falling back to the bundled pyship icon.
+"""
+
 from typing import Callable
 from pathlib import Path
 

--- a/pyship/installer.py
+++ b/pyship/installer.py
@@ -1,0 +1,41 @@
+"""
+Shared installer naming.
+
+Both installer types pyship produces - the NSIS installer (``.exe``) and the
+MSIX package (``.msix``) - are written to the ``installers/`` directory in the
+target project and follow the same ``{app_name}_installer_{target_os}.{ext}``
+naming convention (``target_os`` is e.g. ``win64``). This module is the single
+source of truth for that convention.
+"""
+
+from pathlib import Path
+
+from typeguard import typechecked
+
+from pyshipupdate import get_target_os
+
+#: Name of the directory (inside the target project dir) that receives installers.
+INSTALLERS_DIR_NAME = "installers"
+
+
+@typechecked
+def installer_file_name(app_name: str, extension: str) -> str:
+    """
+    Return the canonical installer file name for an app.
+
+    :param app_name: target application name
+    :param extension: installer file extension without the dot, e.g. ``"exe"`` or ``"msix"``
+    :return: file name such as ``"myapp_installer_win64.exe"``
+    """
+    return f"{app_name}_installer_{get_target_os()}.{extension}"
+
+
+@typechecked
+def get_installers_dir(project_dir: Path) -> Path:
+    """
+    Return the installers output directory for a target project.
+
+    :param project_dir: target application project directory
+    :return: path to the project's ``installers/`` directory (not created)
+    """
+    return Path(project_dir, INSTALLERS_DIR_NAME)

--- a/pyship/launcher_stub.py
+++ b/pyship/launcher_stub.py
@@ -1,3 +1,11 @@
+"""
+C# launcher stub: source template and csc.exe compilation.
+
+The stub is a small native .exe that locates the newest CLIP directory and
+starts the standalone Python launcher script with it, logging to the user's
+LocalAppData log directory.
+"""
+
 import subprocess
 import tempfile
 from pathlib import Path

--- a/pyship/logging.py
+++ b/pyship/logging.py
@@ -1,3 +1,7 @@
+"""
+Logging: :class:`PyshipLog` (balsa-based logger setup) and process output logging.
+"""
+
 from typeguard import typechecked
 from typing import Callable
 
@@ -8,6 +12,8 @@ from pyship import __application_name__
 
 
 class PyshipLog(Balsa):
+    """pyship's balsa-based logger configuration."""
+
     pass
 
 

--- a/pyship/msix.py
+++ b/pyship/msix.py
@@ -1,3 +1,12 @@
+"""
+MSIX package creation for Microsoft Store distribution or sideloading.
+
+Writes an AppxManifest.xml and Store logo assets into the app directory, then
+packs it with makeappx.exe from the Windows SDK. Run after ``run_nsis()`` so
+that MSIX-specific files added to the app directory do not affect the NSIS
+installer.
+"""
+
 import re
 import shutil
 import struct
@@ -10,7 +19,8 @@ from typeguard import typechecked
 from balsa import get_logger
 
 from pyship import __application_name__, AppInfo, pyship_print, subprocess_run
-from pyship.signing import _SDK_BIN_DIR
+from pyship.installer import get_installers_dir, installer_file_name
+from pyship.windows_sdk import WINDOWS_SDK_BIN_DIR, find_sdk_tool
 
 log = get_logger(__application_name__)
 
@@ -54,31 +64,14 @@ _MANIFEST_TEMPLATE = """\
 
 
 @typechecked
-def _find_makeappx(_sdk_bin_dir: Path = _SDK_BIN_DIR) -> Union[Path, None]:
+def _find_makeappx(_sdk_bin_dir: Path = WINDOWS_SDK_BIN_DIR) -> Union[Path, None]:
     """
     Locate makeappx.exe from the Windows SDK bin directory.
+
     :param _sdk_bin_dir: Windows SDK bin directory to search
-    :return: path to makeappx.exe with the highest SDK version, or None if not found
+    :return: path to makeappx.exe from the highest SDK version, or None if not found
     """
-    if not _sdk_bin_dir.is_dir():
-        return None
-
-    candidates = []
-    for child in _sdk_bin_dir.iterdir():
-        if child.is_dir() and child.name.startswith("10."):
-            makeappx = Path(child, "x64", "makeappx.exe")
-            if makeappx.exists():
-                try:
-                    version_tuple = tuple(int(x) for x in child.name.split("."))
-                    candidates.append((version_tuple, makeappx))
-                except ValueError:
-                    pass
-
-    if not candidates:
-        return None
-
-    candidates.sort(key=lambda x: x[0], reverse=True)
-    return candidates[0][1]
+    return find_sdk_tool("makeappx.exe", _sdk_bin_dir)
 
 
 @typechecked
@@ -178,11 +171,9 @@ def create_msix(
         dest.write_bytes(placeholder)
 
     # Pack with makeappx
-    from pyshipupdate import get_target_os
-
-    installers_dir = Path(target_app_info.project_dir, "installers")
-    installers_dir.mkdir(parents=True, exist_ok=True)
-    msix_path = Path(installers_dir, f"{target_app_info.name}_installer_{get_target_os()}.msix")
+    installers_dir = get_installers_dir(target_app_info.project_dir)
+    installers_dir.mkdir(parents=True, exist_ok=True)  # run_nsis() already cleared it; do not clear again or the NSIS installer would be deleted
+    msix_path = Path(installers_dir, installer_file_name(target_app_info.name, "msix"))
 
     cmd = [str(makeappx_path), "pack", "/d", str(app_dir), "/p", str(msix_path), "/o"]
     pyship_print(f'building MSIX package "{msix_path}"')

--- a/pyship/nsis.py
+++ b/pyship/nsis.py
@@ -1,3 +1,10 @@
+"""
+NSIS installer generation.
+
+Generates an NSIS script (.nsi) for the target application and runs
+makensis.exe to build the Windows installer executable.
+"""
+
 import datetime
 import os
 from pathlib import Path
@@ -12,6 +19,7 @@ from typing import Union
 from pyshipupdate import mkdirs, get_target_os
 from pyship import __application_name__, AppInfo, subprocess_run, pyship_print, get_icon, PyshipLicenseFileDoesNotExist
 from pyship.ci import is_ci
+from pyship.installer import INSTALLERS_DIR_NAME, installer_file_name
 
 log = get_logger(__application_name__)
 
@@ -33,11 +41,19 @@ def get_folder_size(folder_path: Path) -> int:
 @typechecked
 def run_nsis(target_app_info: AppInfo, target_app_version: VersionInfo, app_dir: Path) -> Union[Path, None]:
     """
-    run nsis
+    Generate an NSIS script for the target application and run makensis.exe on it.
+
+    The generated installer is written to the project's ``installers/`` directory
+    (which is cleared first). The zipped CLIP update payload (``*.clip``) is
+    excluded from the installer contents. Requires a LICENSE file in the target
+    project; a CRLF-normalized copy is placed in the build tree for NSIS.
+
     :param target_app_info: target app info
     :param target_app_version: target app version
-    :param app_dir: application dir
-    :return: path to installer exe, or None if NSIS not available (e.g. in CI)
+    :param app_dir: application dir packed into the installer
+    :return: path to the installer exe, or None if NSIS is not available (e.g. in CI)
+    :raises PyshipLicenseFileDoesNotExist: if the target project has no LICENSE file
+    :raises FileNotFoundError: if makensis.exe is missing outside of CI
     """
 
     # basic format is from:
@@ -62,9 +78,9 @@ def run_nsis(target_app_info: AppInfo, target_app_version: VersionInfo, app_dir:
         pyship_print(f'building installer "{nsis_file_path}" ("{nsis_file_path.absolute()}")')
 
         exe_name = f"{target_app_info.name}.exe"
-        installers_folder = "installers"
-        mkdirs(Path(target_app_info.project_dir, installers_folder), remove_first=True)
-        installer_exe_path = Path(installers_folder, f"{target_app_info.name}_installer_{get_target_os()}.exe")
+        mkdirs(Path(target_app_info.project_dir, INSTALLERS_DIR_NAME), remove_first=True)
+        # relative path: the .nsi outFile is resolved from the project dir where makensis runs
+        installer_exe_path = Path(INSTALLERS_DIR_NAME, installer_file_name(target_app_info.name, "exe"))
 
         nsis_lines = []
         nsis_lines.append("")

--- a/pyship/path.py
+++ b/pyship/path.py
@@ -1,7 +1,12 @@
+"""
+NullPath: a sentinel Path subclass for not-yet-initialized path fields.
+"""
+
 from pathlib import Path
 
 
-# Path doesn't allow for sub-typing, but this is a workaround:
+# Path doesn't allow for direct sub-typing, but this is a workaround:
 class NullPath(type(Path())):  # type: ignore
-    # A "null" Path. Used to represent a class of type Path but it's not initialized to a actual OS path yet.
+    """A "null" Path: has Path's type but is not initialized to an actual OS path yet."""
+
     pass

--- a/pyship/pyship.py
+++ b/pyship/pyship.py
@@ -18,7 +18,7 @@ from pyship import __application_name__ as pyship_application_name
 from pyship import __author__ as pyship_author
 from pyship import __version__ as pyship_version
 from pyship import run_nsis, create_clip, create_pyship_launcher, pyship_print, APP_DIR_NAME, create_clip_file, get_app_info, PyShipCloud
-from pyship.signing import sign_if_configured, check_signing_available, is_rdp_session
+from pyship.signing import sign_if_configured, check_signing_available, is_rdp_session, is_token_signing_configured, RDP_SIGNING_BLOCKED_MESSAGE
 from pyship.msix import create_msix
 from pyship import PyshipNoAppName
 from pyship.exceptions import PyshipSigningUnavailable
@@ -147,13 +147,11 @@ class PyShip:
 
         # Pre-flight signing check
         if self.code_sign:
-            token_mode = self.certificate_sha1 is not None or self.certificate_subject is not None or self.certificate_auto_select
+            token_mode = is_token_signing_configured(self.certificate_sha1, self.certificate_subject, self.certificate_auto_select)
             if token_mode and is_rdp_session():
-                pyship_print(
-                    "RDP session detected - hardware token signing is not supported over Remote Desktop. "
-                    "Token PIN entry does not work over RDP, and failed attempts may lock your token. "
-                    "Please sign from a local console session."
-                )
+                # soft-fail (return None instead of raising) so build scripts see a missing
+                # installer rather than a traceback; check_signing_available would raise below
+                pyship_print(RDP_SIGNING_BLOCKED_MESSAGE)
                 return None
             available = check_signing_available(
                 pfx_path=self.pfx_path,

--- a/pyship/signing.py
+++ b/pyship/signing.py
@@ -26,10 +26,18 @@ from balsa import get_logger
 from pyship import __application_name__
 from pyship.custom_print import pyship_print
 from pyship.subprocess import subprocess_run
+from pyship.windows_sdk import WINDOWS_SDK_BIN_DIR, find_sdk_tool
 
 log = get_logger(__application_name__)
 
-_SDK_BIN_DIR = Path(r"C:\Program Files (x86)\Windows Kits\10\bin")
+_SDK_BIN_DIR = WINDOWS_SDK_BIN_DIR  # backwards-compatible alias
+
+#: User-facing message shown when hardware-token signing is blocked by an RDP session.
+RDP_SIGNING_BLOCKED_MESSAGE = (
+    "RDP session detected - hardware token signing is not supported over Remote Desktop. "
+    "Token PIN entry does not work over RDP, and failed attempts may lock your token. "
+    "Please sign from a local console session."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -38,34 +46,30 @@ _SDK_BIN_DIR = Path(r"C:\Program Files (x86)\Windows Kits\10\bin")
 
 
 @typechecked
-def _find_signtool(_sdk_bin_dir: Path = _SDK_BIN_DIR) -> Union[Path, None]:
+def is_token_signing_configured(certificate_sha1: Union[str, None] = None, certificate_subject: Union[str, None] = None, certificate_auto_select: bool = False) -> bool:
+    """
+    Return True when any hardware-token certificate selector is configured.
+
+    Token mode is active when a SHA1 thumbprint, a certificate subject, or
+    auto-select is provided; PFX mode is configured separately via a PFX path.
+
+    :param certificate_sha1: SHA1 thumbprint of certificate in the Windows Certificate Store
+    :param certificate_subject: subject name of certificate in the Windows Certificate Store
+    :param certificate_auto_select: True to let signtool auto-select the certificate (``/a``)
+    :return: True if hardware-token signing is configured
+    """
+    return certificate_sha1 is not None or certificate_subject is not None or certificate_auto_select
+
+
+@typechecked
+def _find_signtool(_sdk_bin_dir: Path = WINDOWS_SDK_BIN_DIR) -> Union[Path, None]:
     """
     Locate signtool.exe from the Windows SDK bin directory.
-    Scans versioned subdirectories (e.g. ``10.0.22621.0``) and returns
-    the ``x64/signtool.exe`` from the highest version found.
 
     :param _sdk_bin_dir: Windows SDK bin directory to search
-    :return: path to signtool.exe, or None if not found
+    :return: path to signtool.exe from the highest SDK version, or None if not found
     """
-    if not _sdk_bin_dir.is_dir():
-        return None
-
-    candidates = []
-    for child in _sdk_bin_dir.iterdir():
-        if child.is_dir() and child.name.startswith("10."):
-            signtool = Path(child, "x64", "signtool.exe")
-            if signtool.exists():
-                try:
-                    version_tuple = tuple(int(x) for x in child.name.split("."))
-                    candidates.append((version_tuple, signtool))
-                except ValueError:
-                    pass
-
-    if not candidates:
-        return None
-
-    candidates.sort(key=lambda x: x[0], reverse=True)
-    return candidates[0][1]
+    return find_sdk_tool("signtool.exe", _sdk_bin_dir)
 
 
 @typechecked
@@ -259,16 +263,11 @@ def check_signing_available(
         log.warning(f"PFX certificate file does not exist: {pfx_path}")
         return False
 
-    token_mode = certificate_sha1 is not None or certificate_subject is not None or certificate_auto_select
-    if not token_mode:
+    if not is_token_signing_configured(certificate_sha1, certificate_subject, certificate_auto_select):
         return False
 
     if is_rdp_session():
-        pyship_print(
-            "RDP session detected - hardware token signing is not supported over Remote Desktop. "
-            "Token PIN entry does not work over RDP, and failed attempts may lock your token. "
-            "Please sign from a local console session."
-        )
+        pyship_print(RDP_SIGNING_BLOCKED_MESSAGE)
         return False
 
     if not is_token_present():
@@ -426,7 +425,7 @@ def sign_if_configured(
         log.debug("file_path is None; skipping signing")
         return False
 
-    token_mode = certificate_sha1 is not None or certificate_subject is not None or certificate_auto_select
+    token_mode = is_token_signing_configured(certificate_sha1, certificate_subject, certificate_auto_select)
     pfx_mode = pfx_path is not None
 
     if pfx_mode and token_mode:
@@ -448,7 +447,7 @@ def sign_if_configured(
             signtool_path=signtool_path,
         )
 
-    if pfx_mode:
+    if pfx_path is not None:
         if certificate_password is None:
             log.warning("pfx_path is set but certificate_password not configured; skipping signing")
             return False

--- a/pyship/subprocess.py
+++ b/pyship/subprocess.py
@@ -1,3 +1,10 @@
+"""
+Subprocess wrapper used throughout pyship.
+
+:func:`subprocess_run` strips ``PATH``/``PYTHONPATH`` from the child
+environment so tools run predictably regardless of the developer's shell setup.
+"""
+
 import subprocess
 from pathlib import Path
 from typing import Callable

--- a/pyship/uv_util.py
+++ b/pyship/uv_util.py
@@ -1,3 +1,8 @@
+"""
+uv helpers: bootstrap the uv binary, install/copy standalone Python,
+install packages with ``uv pip``, and build wheels with ``uv build``.
+"""
+
 import platform
 import shutil
 import subprocess

--- a/pyship/windows_sdk.py
+++ b/pyship/windows_sdk.py
@@ -1,0 +1,49 @@
+"""
+Windows SDK command-line tool discovery.
+
+The Windows SDK installs versioned tool directories under
+``C:\\Program Files (x86)\\Windows Kits\\10\\bin`` (e.g. ``10.0.22621.0``).
+:func:`find_sdk_tool` locates a tool (signtool.exe, makeappx.exe, ...) from the
+highest installed SDK version, and is shared by the code-signing and MSIX modules.
+"""
+
+from pathlib import Path
+from typing import Union
+
+from typeguard import typechecked
+
+#: Default Windows SDK bin directory searched by :func:`find_sdk_tool`.
+WINDOWS_SDK_BIN_DIR = Path(r"C:\Program Files (x86)\Windows Kits\10\bin")
+
+
+@typechecked
+def find_sdk_tool(tool_name: str, sdk_bin_dir: Path = WINDOWS_SDK_BIN_DIR) -> Union[Path, None]:
+    """
+    Locate a Windows SDK tool executable.
+
+    Scans versioned subdirectories of *sdk_bin_dir* (e.g. ``10.0.22621.0``) and
+    returns the ``x64/<tool_name>`` from the highest SDK version that contains it.
+
+    :param tool_name: executable file name, e.g. ``"signtool.exe"`` or ``"makeappx.exe"``
+    :param sdk_bin_dir: Windows SDK bin directory to search
+    :return: path to the tool from the highest SDK version, or None if not found
+    """
+    if not sdk_bin_dir.is_dir():
+        return None
+
+    candidates = []
+    for child in sdk_bin_dir.iterdir():
+        if child.is_dir() and child.name.startswith("10."):
+            tool_path = Path(child, "x64", tool_name)
+            if tool_path.exists():
+                try:
+                    version_tuple = tuple(int(x) for x in child.name.split("."))
+                    candidates.append((version_tuple, tool_path))
+                except ValueError:
+                    pass
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    return candidates[0][1]


### PR DESCRIPTION
## Summary
Deep code review of the `pyship` package focused on modularity, DRY, documentation, and installer-type consistency.

### New shared modules
- **`pyship/windows_sdk.py`** — `find_sdk_tool()` centralizes the Windows SDK versioned-directory scan that was duplicated (~25 lines each) in `signing._find_signtool` and `msix._find_makeappx`. Both remain as thin wrappers, so existing call sites and unit tests are unchanged.
- **`pyship/installer.py`** — single source of truth for the `{app}_installer_{target_os}.{ext}` naming convention and the `installers/` output directory, previously hard-coded independently in `nsis.py` and `msix.py`.

### De-duplication
- `is_token_signing_configured()` replaces the `certificate_sha1 is not None or certificate_subject is not None or certificate_auto_select` expression that appeared in three places (`pyship.py`, `check_signing_available`, `sign_if_configured`).
- `RDP_SIGNING_BLOCKED_MESSAGE` constant replaces the RDP warning text duplicated in `pyship.py` and `signing.py`.
- `msix.py` no longer imports `_SDK_BIN_DIR` from `signing.py` (crossed module concern) and its inline `get_target_os` import is gone.

### Documentation
- Module docstrings added to every module in the package; missing function/class docstrings filled in (`AppInfo`, all exceptions, `run_nsis`, `pyship_print`, `get_arguments`, app_info helpers, etc.), Sphinx-style per project convention.

### Installer type consistency
- `get_target_os()` returns `win64`, so real artifacts are `{app}_installer_win64.exe/.msix` — but the README documented `_win.exe`/`_win.msix` in four places. README corrected and now explains the platform suffix. CLAUDE.md project structure updated with the new and previously-missing modules.

### Behavior
No behavior changes intended. One `ty` narrowing fix in `sign_if_configured` (test `pfx_path is not None` directly).

## Test plan
- [x] `ruff format` / `ruff check` clean
- [x] `ty check` clean
- [x] 231 fast unit tests pass locally (`-k "test_a or test_b"`)
- [ ] Full CI suite (Python 3.11–3.14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)