### PR TITLE
Make tkinter import lazy in custom_print

### DIFF
--- a/pyship/custom_print.py
+++ b/pyship/custom_print.py
@@ -1,20 +1,44 @@
 """
 User-facing output: :func:`pyship_print` combines logging with a timestamped
 console print (or a tkinter label in GUI mode).
+
+tkinter is imported lazily, and only for GUI mode - importing this module (and
+therefore the pyship package) must work in headless environments without a
+display or a tkinter installation.
 """
 
-from tkinter import Tk, Label
 from datetime import datetime
+from typing import TYPE_CHECKING, Union
 
 from typeguard import typechecked
 from balsa import get_logger
 
 from pyship import __application_name__
 
+if TYPE_CHECKING:
+    from tkinter import Tk
+
 log = get_logger(__application_name__)
 
-window = Tk()
-window.withdraw()  # no main window
+# hidden tkinter root window for GUI-mode output, created on first use
+_window: Union["Tk", None] = None
+
+
+def _get_window() -> Union["Tk", None]:
+    """
+    Create (once) and return the hidden tkinter root window used for GUI-mode
+    output, or None if tkinter is unavailable (headless environment).
+    """
+    global _window
+    if _window is None:
+        try:
+            from tkinter import Tk
+
+            _window = Tk()
+            _window.withdraw()  # no main window until there is something to show
+        except Exception as exc:
+            log.warning(f"tkinter unavailable, falling back to console output: {exc}")
+    return _window
 
 
 @typechecked
@@ -23,15 +47,20 @@ def pyship_print(s: str, ui: str = "cli"):
     Emit a user-facing message: always logged, and shown on the console
     (timestamped) or in a GUI window depending on *ui*.
 
+    In GUI mode, falls back to console output if tkinter is unavailable.
+
     :param s: message to display
     :param ui: "cli" (default) for console output, "gui" for a tkinter window
     """
     log.info(s)
     if ui == "gui":
-        label = Label(window, text=s)  # adds to the window each time
-        label.grid()
-        label.update()
-        window.deiconify()
-    else:
-        print_string = f"{datetime.now().astimezone().isoformat()} : {s}"
-        print(print_string)
+        window = _get_window()
+        if window is not None:
+            from tkinter import Label
+
+            label = Label(window, text=s)  # adds to the window each time
+            label.grid()
+            label.update()
+            window.deiconify()
+            return
+    print(f"{datetime.now().astimezone().isoformat()} : {s}")


### PR DESCRIPTION
## Summary
- `custom_print.py` created a hidden `Tk()` root window at import time, so importing the pyship package required a display and a tkinter installation — crashing in headless environments even for CLI-only use.
- tkinter is now imported and the hidden window created lazily, on the first GUI-mode `pyship_print()` call only (`TYPE_CHECKING` import keeps type checking precise with no runtime cost).
- If tkinter is unavailable, GUI mode logs a warning and falls back to timestamped console output instead of crashing.

## Test plan
- [x] Headless smoke test: with `tkinter` blocked, `import pyship` succeeds, CLI printing works, and `ui="gui"` falls back to console
- [x] `ruff` / `ty` clean, 231 fast unit tests pass locally
- [ ] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)