### PR TITLE
Log env var names only in subprocess_run, not values

### DIFF
--- a/pyship/subprocess.py
+++ b/pyship/subprocess.py
@@ -48,8 +48,8 @@ def subprocess_run(
         except KeyError:
             pass
 
-    for k, v in run_env.items():
-        log.debug(f"{k}={v}")
+    # log env var names only - values may contain secrets (signing PINs, AWS keys)
+    log.debug(f"run_env variables: {sorted(run_env.keys())}")
     log.info(f"{mute_output=}")
     log.info(f"{os.getcwd()=}")
     log.info(f"{cmd=}")


### PR DESCRIPTION
## Summary
- `subprocess_run` logged every environment variable's value at debug level on every call. Values can contain secrets (`PYSHIP_SIGNING_CERTIFICATE_PIN`, AWS credentials), which would leak into log files whenever debug logging is enabled — and the dump was noisy besides.
- Now logs only the sorted variable names, keeping the diagnostic signal (what was present in the child environment) without the values.

## Test plan
- [x] `ruff` / `ty` clean, 231 fast unit tests pass locally
- [ ] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)