### PR TITLE
Introduce SigningConfig dataclass to replace flat signing parameters

### DIFF
--- a/pyship/__init__.py
+++ b/pyship/__init__.py
@@ -20,7 +20,7 @@ from .app_info import AppInfo, get_app_info, get_app_info_py_project
 from .get_icon import get_icon
 from .nsis import run_nsis
 from .download import file_download, extract, PyshipDownloadError
-from .signing import sign_if_configured, sign_file_token, is_token_present, is_certificate_in_store, is_rdp_session, check_signing_available, is_token_signing_configured
+from .signing import SigningConfig, DEFAULT_TIMESTAMP_URL, sign_if_configured, sign_file_token, is_token_present, is_certificate_in_store, is_rdp_session, check_signing_available
 from .msix import create_msix
 from .create_launcher import create_pyship_launcher
 from .clip import create_base_clip, install_target_app, create_clip, create_clip_file

--- a/pyship/pyship.py
+++ b/pyship/pyship.py
@@ -18,7 +18,7 @@ from pyship import __application_name__ as pyship_application_name
 from pyship import __author__ as pyship_author
 from pyship import __version__ as pyship_version
 from pyship import run_nsis, create_clip, create_pyship_launcher, pyship_print, APP_DIR_NAME, create_clip_file, get_app_info, PyShipCloud
-from pyship.signing import sign_if_configured, check_signing_available, is_rdp_session, is_token_signing_configured, RDP_SIGNING_BLOCKED_MESSAGE
+from pyship.signing import SigningConfig, sign_if_configured, check_signing_available, is_rdp_session, RDP_SIGNING_BLOCKED_MESSAGE, DEFAULT_TIMESTAMP_URL
 from pyship.msix import create_msix
 from pyship import PyshipNoAppName
 from pyship.exceptions import PyshipSigningUnavailable
@@ -60,7 +60,7 @@ class PyShip:
     # --- code signing (common) ---
     code_sign: bool = False  # master switch: True → sign executables; failure aborts ship()
     certificate_password: Union[str, None] = None  # PFX password or hardware token PIN
-    timestamp_url: str = "http://timestamp.digicert.com"  # RFC 3161 timestamp server
+    timestamp_url: str = DEFAULT_TIMESTAMP_URL  # RFC 3161 timestamp server
     signtool_path: Union[Path, None] = None  # explicit signtool.exe; auto-discovered if None
 
     # --- code signing (PFX mode) ---
@@ -93,7 +93,24 @@ class PyShip:
             return self.certificate_password
         return os.environ.get(SIGNING_PIN_ENV_VAR)
 
-    def _sign_or_raise(self, file_path: Union[Path, None], effective_password: Union[str, None]) -> None:
+    def _signing_config(self) -> SigningConfig:
+        """
+        Collect the flat signing fields into a :class:`SigningConfig`,
+        with the password/PIN resolved (explicit value or environment variable).
+        """
+        return SigningConfig(
+            pfx_path=self.pfx_path,
+            certificate_password=self._resolve_password(),
+            timestamp_url=self.timestamp_url,
+            signtool_path=self.signtool_path,
+            certificate_sha1=self.certificate_sha1,
+            certificate_subject=self.certificate_subject,
+            certificate_auto_select=self.certificate_auto_select,
+            certificate_csp=self.certificate_csp,
+            certificate_key_container=self.certificate_key_container,
+        )
+
+    def _sign_or_raise(self, file_path: Union[Path, None], signing_config: SigningConfig) -> None:
         """
         Sign *file_path* using the configured mode.  Raises
         :class:`PyshipSigningUnavailable` on failure.
@@ -101,21 +118,9 @@ class PyShip:
         Only called when ``self.code_sign`` is True.
 
         :param file_path: path to the executable to sign
-        :param effective_password: resolved PFX password or token PIN
+        :param signing_config: resolved signing configuration
         """
-        signed = sign_if_configured(
-            file_path,
-            self.pfx_path,
-            effective_password,
-            self.timestamp_url,
-            self.signtool_path,
-            certificate_sha1=self.certificate_sha1,
-            certificate_subject=self.certificate_subject,
-            certificate_auto_select=self.certificate_auto_select,
-            certificate_csp=self.certificate_csp,
-            certificate_key_container=self.certificate_key_container,
-        )
-        if not signed:
+        if not sign_if_configured(file_path, signing_config):
             raise PyshipSigningUnavailable(f"failed to sign {file_path}")
 
     # ------------------------------------------------------------------
@@ -143,23 +148,16 @@ class PyShip:
 
         cache_dir = Path(platformdirs.user_cache_dir(pyship_application_name, pyship_author))
 
-        effective_password = self._resolve_password()
+        signing_config = self._signing_config()
 
         # Pre-flight signing check
         if self.code_sign:
-            token_mode = is_token_signing_configured(self.certificate_sha1, self.certificate_subject, self.certificate_auto_select)
-            if token_mode and is_rdp_session():
+            if signing_config.token_mode and is_rdp_session():
                 # soft-fail (return None instead of raising) so build scripts see a missing
                 # installer rather than a traceback; check_signing_available would raise below
                 pyship_print(RDP_SIGNING_BLOCKED_MESSAGE)
                 return None
-            available = check_signing_available(
-                pfx_path=self.pfx_path,
-                certificate_sha1=self.certificate_sha1,
-                certificate_subject=self.certificate_subject,
-                certificate_auto_select=self.certificate_auto_select,
-            )
-            if not available:
+            if not check_signing_available(signing_config):
                 raise PyshipSigningUnavailable("code_sign is True but signing infrastructure is not available")
 
         target_app_info = get_app_info(self.project_dir, Path(self.project_dir, self.dist_dir), cache_dir)
@@ -173,14 +171,14 @@ class PyShip:
 
             launcher_exe_path = create_pyship_launcher(target_app_info, app_dir)
             if self.code_sign:
-                self._sign_or_raise(launcher_exe_path, effective_password)
+                self._sign_or_raise(launcher_exe_path, signing_config)
 
             clip_dir = create_clip(target_app_info, app_dir, Path(self.project_dir, self.dist_dir), cache_dir, python_version=self.python_version)
 
             assert isinstance(target_app_info.version, VersionInfo)
             installer_exe_path = run_nsis(target_app_info, target_app_info.version, app_dir)
             if installer_exe_path is not None and self.code_sign:
-                self._sign_or_raise(installer_exe_path, effective_password)
+                self._sign_or_raise(installer_exe_path, signing_config)
 
             if self.msix:
                 if self.msix_publisher is None:
@@ -188,7 +186,7 @@ class PyShip:
                 else:
                     msix_path = create_msix(target_app_info, app_dir, self.msix_publisher, self.store_assets_dir, self.makeappx_path)
                     if msix_path is not None and self.code_sign:
-                        self._sign_or_raise(msix_path, effective_password)
+                        self._sign_or_raise(msix_path, signing_config)
 
             if self.upload and installer_exe_path is not None:
                 if self.cloud_profile is None and self.cloud_id is None:

--- a/pyship/signing.py
+++ b/pyship/signing.py
@@ -14,6 +14,7 @@ import hashlib
 import ssl
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Union
 
@@ -39,26 +40,49 @@ RDP_SIGNING_BLOCKED_MESSAGE = (
     "Please sign from a local console session."
 )
 
+#: Default RFC 3161 timestamp server.
+DEFAULT_TIMESTAMP_URL = "http://timestamp.digicert.com"
+
+
+@dataclass
+class SigningConfig:
+    """
+    Everything needed to sign an executable, in one place.
+
+    Two mutually exclusive modes:
+
+    - **PFX mode** (:attr:`pfx_mode`): active when :attr:`pfx_path` is set;
+      :attr:`certificate_password` is the PFX password (required to sign).
+    - **Token mode** (:attr:`token_mode`): active when any of
+      :attr:`certificate_sha1`, :attr:`certificate_subject`, or
+      :attr:`certificate_auto_select` is set; :attr:`certificate_password` is
+      the optional token PIN (the token middleware may prompt interactively).
+    """
+
+    pfx_path: Union[Path, None] = None  # PFX certificate file (PFX mode)
+    certificate_password: Union[str, None] = None  # PFX password or hardware token PIN
+    timestamp_url: str = DEFAULT_TIMESTAMP_URL  # RFC 3161 timestamp server URL
+    signtool_path: Union[Path, None] = None  # explicit signtool.exe; auto-discovered if None
+    certificate_sha1: Union[str, None] = None  # SHA1 thumbprint in Windows Certificate Store (token mode, /sha1)
+    certificate_subject: Union[str, None] = None  # certificate subject name (token mode, /n)
+    certificate_auto_select: bool = False  # auto-select best signing certificate (token mode, /a)
+    certificate_csp: Union[str, None] = None  # cryptographic service provider (token mode, /csp)
+    certificate_key_container: Union[str, None] = None  # key container name (token mode, /kc)
+
+    @property
+    def pfx_mode(self) -> bool:
+        """True when PFX-file signing is configured."""
+        return self.pfx_path is not None
+
+    @property
+    def token_mode(self) -> bool:
+        """True when any hardware-token certificate selector is configured."""
+        return self.certificate_sha1 is not None or self.certificate_subject is not None or self.certificate_auto_select
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers (shared by PFX and token signing)
 # ---------------------------------------------------------------------------
-
-
-@typechecked
-def is_token_signing_configured(certificate_sha1: Union[str, None] = None, certificate_subject: Union[str, None] = None, certificate_auto_select: bool = False) -> bool:
-    """
-    Return True when any hardware-token certificate selector is configured.
-
-    Token mode is active when a SHA1 thumbprint, a certificate subject, or
-    auto-select is provided; PFX mode is configured separately via a PFX path.
-
-    :param certificate_sha1: SHA1 thumbprint of certificate in the Windows Certificate Store
-    :param certificate_subject: subject name of certificate in the Windows Certificate Store
-    :param certificate_auto_select: True to let signtool auto-select the certificate (``/a``)
-    :return: True if hardware-token signing is configured
-    """
-    return certificate_sha1 is not None or certificate_subject is not None or certificate_auto_select
 
 
 @typechecked
@@ -238,32 +262,25 @@ def is_certificate_in_store(certificate_sha1: Union[str, None] = None, certifica
 
 
 @typechecked
-def check_signing_available(
-    pfx_path: Union[Path, None] = None,
-    certificate_sha1: Union[str, None] = None,
-    certificate_subject: Union[str, None] = None,
-    certificate_auto_select: bool = False,
-) -> bool:
+def check_signing_available(config: SigningConfig) -> bool:
     """
     Pre-flight check: verify that signing infrastructure is available.
 
     For PFX mode, checks that the file exists.  For token mode, checks that
-    a smart-card device is present and (unless *certificate_auto_select* is
-    used alone) that the specific certificate is in the Windows store.
+    the session is not RDP, a smart-card device is present, and (unless
+    auto-select is used alone) that the specific certificate is in the
+    Windows store.
 
-    :param pfx_path: path to PFX certificate file (PFX mode)
-    :param certificate_sha1: SHA1 thumbprint for cert store lookup (token mode)
-    :param certificate_subject: subject name for cert store lookup (token mode)
-    :param certificate_auto_select: True to auto-select certificate (token mode)
+    :param config: signing configuration
     :return: True if signing infrastructure appears available
     """
-    if pfx_path is not None:
-        if pfx_path.exists():
+    if config.pfx_path is not None:
+        if config.pfx_path.exists():
             return True
-        log.warning(f"PFX certificate file does not exist: {pfx_path}")
+        log.warning(f"PFX certificate file does not exist: {config.pfx_path}")
         return False
 
-    if not is_token_signing_configured(certificate_sha1, certificate_subject, certificate_auto_select):
+    if not config.token_mode:
         return False
 
     if is_rdp_session():
@@ -275,10 +292,10 @@ def check_signing_available(
         return False
 
     # For auto-select we can't check a specific cert, just confirm hardware is present
-    if certificate_auto_select and certificate_sha1 is None and certificate_subject is None:
+    if config.certificate_auto_select and config.certificate_sha1 is None and config.certificate_subject is None:
         return True
 
-    if not is_certificate_in_store(certificate_sha1=certificate_sha1, certificate_subject=certificate_subject):
+    if not is_certificate_in_store(certificate_sha1=config.certificate_sha1, certificate_subject=config.certificate_subject):
         pyship_print("certificate not found in Windows Certificate Store")
         return False
 
@@ -291,62 +308,49 @@ def check_signing_available(
 
 
 @typechecked
-def sign_file(file_path: Path, pfx_path: Path, certificate_password: str, timestamp_url: str, signtool_path: Union[Path, None] = None) -> bool:
+def sign_file(file_path: Path, config: SigningConfig) -> bool:
     """
     Sign a file using signtool.exe with a PFX certificate.
 
+    Requires ``config.pfx_path`` and ``config.certificate_password`` to be set.
+
     :param file_path: path to the file to sign
-    :param pfx_path: path to the PFX certificate file
-    :param certificate_password: password for the PFX certificate
-    :param timestamp_url: RFC 3161 timestamp server URL
-    :param signtool_path: explicit path to signtool.exe; auto-discovered if None
+    :param config: signing configuration (PFX mode)
     :return: True if signing succeeded, False otherwise
     """
-    signtool_path = _resolve_signtool(signtool_path)
+    signtool_path = _resolve_signtool(config.signtool_path)
     if signtool_path is None:
         return False
 
     if not file_path.exists():
         log.error(f"file to sign does not exist: {file_path}")
         return False
-    if not pfx_path.exists():
-        log.error(f"PFX certificate file does not exist: {pfx_path}")
+    if config.pfx_path is None or not config.pfx_path.exists():
+        log.error(f"PFX certificate file does not exist: {config.pfx_path}")
+        return False
+    if config.certificate_password is None:
+        log.error("PFX mode requires certificate_password")
         return False
 
-    cmd = [str(signtool_path), "sign", "/f", str(pfx_path), "/p", certificate_password, "/tr", timestamp_url, "/td", "sha256", "/fd", "sha256", str(file_path)]
+    cmd = [str(signtool_path), "sign", "/f", str(config.pfx_path), "/p", config.certificate_password, "/tr", config.timestamp_url, "/td", "sha256", "/fd", "sha256", str(file_path)]
     return _run_signtool(cmd, file_path)
 
 
 @typechecked
-def sign_file_token(
-    file_path: Path,
-    timestamp_url: str,
-    certificate_sha1: Union[str, None] = None,
-    certificate_subject: Union[str, None] = None,
-    certificate_auto_select: bool = False,
-    token_pin: Union[str, None] = None,
-    certificate_csp: Union[str, None] = None,
-    certificate_key_container: Union[str, None] = None,
-    signtool_path: Union[Path, None] = None,
-) -> bool:
+def sign_file_token(file_path: Path, config: SigningConfig) -> bool:
     """
     Sign a file using signtool.exe with a certificate from the Windows Certificate Store.
 
     Exactly one certificate selector (``certificate_sha1``, ``certificate_subject``,
-    or ``certificate_auto_select``) must be provided.
+    or ``certificate_auto_select``) must be set in *config*.
+    ``config.certificate_password`` is used as the token PIN if provided;
+    otherwise the token middleware may prompt interactively.
 
     :param file_path: path to the file to sign
-    :param timestamp_url: RFC 3161 timestamp server URL
-    :param certificate_sha1: SHA1 thumbprint of certificate in the store
-    :param certificate_subject: subject name of certificate in the store
-    :param certificate_auto_select: use ``/a`` flag to auto-select best signing certificate
-    :param token_pin: hardware token PIN (optional; token middleware may prompt interactively)
-    :param certificate_csp: cryptographic service provider name (``/csp``)
-    :param certificate_key_container: key container name (``/kc``)
-    :param signtool_path: explicit path to signtool.exe; auto-discovered if None
+    :param config: signing configuration (token mode)
     :return: True if signing succeeded, False otherwise
     """
-    signtool_path = _resolve_signtool(signtool_path)
+    signtool_path = _resolve_signtool(config.signtool_path)
     if signtool_path is None:
         return False
 
@@ -355,7 +359,7 @@ def sign_file_token(
         return False
 
     # Validate exactly one certificate selector is provided
-    selectors = sum([certificate_sha1 is not None, certificate_subject is not None, certificate_auto_select])
+    selectors = sum([config.certificate_sha1 is not None, config.certificate_subject is not None, config.certificate_auto_select])
     if selectors == 0:
         log.error("no certificate selector provided (need certificate_sha1, certificate_subject, or certificate_auto_select)")
         return False
@@ -366,92 +370,59 @@ def sign_file_token(
     # Build signtool command
     cmd = [str(signtool_path), "sign"]
 
-    if certificate_sha1 is not None:
-        clean_sha1 = _validate_sha1(certificate_sha1)
+    if config.certificate_sha1 is not None:
+        clean_sha1 = _validate_sha1(config.certificate_sha1)
         if clean_sha1 is None:
             return False
         cmd.extend(["/sha1", clean_sha1])
-    elif certificate_subject is not None:
-        cmd.extend(["/n", certificate_subject])
-    elif certificate_auto_select:
+    elif config.certificate_subject is not None:
+        cmd.extend(["/n", config.certificate_subject])
+    elif config.certificate_auto_select:
         cmd.append("/a")
 
-    if certificate_csp is not None:
-        cmd.extend(["/csp", certificate_csp])
-    if certificate_key_container is not None:
-        cmd.extend(["/kc", certificate_key_container])
-    if token_pin is not None:
-        cmd.extend(["/p", token_pin])
+    if config.certificate_csp is not None:
+        cmd.extend(["/csp", config.certificate_csp])
+    if config.certificate_key_container is not None:
+        cmd.extend(["/kc", config.certificate_key_container])
+    if config.certificate_password is not None:
+        cmd.extend(["/p", config.certificate_password])
 
-    cmd.extend(["/tr", timestamp_url, "/td", "sha256", "/fd", "sha256", str(file_path)])
+    cmd.extend(["/tr", config.timestamp_url, "/td", "sha256", "/fd", "sha256", str(file_path)])
     return _run_signtool(cmd, file_path)
 
 
 @typechecked
-def sign_if_configured(
-    file_path: Union[Path, None],
-    pfx_path: Union[Path, None],
-    certificate_password: Union[str, None],
-    timestamp_url: str,
-    signtool_path: Union[Path, None] = None,
-    certificate_sha1: Union[str, None] = None,
-    certificate_subject: Union[str, None] = None,
-    certificate_auto_select: bool = False,
-    certificate_csp: Union[str, None] = None,
-    certificate_key_container: Union[str, None] = None,
-) -> bool:
+def sign_if_configured(file_path: Union[Path, None], config: SigningConfig) -> bool:
     """
-    Sign a file, dispatching to PFX or token mode based on which parameters are set.
+    Sign a file, dispatching to PFX or token mode based on the configuration.
 
-    - **PFX mode** is active when *pfx_path* is not None.
-    - **Token mode** is active when any of *certificate_sha1*, *certificate_subject*,
-      or *certificate_auto_select* is set.
-    - Setting both modes simultaneously is an error.
+    - **PFX mode** is active when ``config.pfx_path`` is set.
+    - **Token mode** is active when any hardware-token certificate selector is set.
+    - Configuring both modes simultaneously is an error.
     - If neither mode is configured, signing is skipped with a warning.
 
     :param file_path: path to the file to sign, or None to skip
-    :param pfx_path: path to the PFX certificate file, or None to skip
-    :param certificate_password: PFX password or hardware token PIN, or None
-    :param timestamp_url: RFC 3161 timestamp server URL
-    :param signtool_path: explicit path to signtool.exe; auto-discovered if None
-    :param certificate_sha1: SHA1 thumbprint of certificate in Windows Certificate Store
-    :param certificate_subject: subject name of certificate in Windows Certificate Store
-    :param certificate_auto_select: use ``/a`` flag to auto-select best signing certificate
-    :param certificate_csp: cryptographic service provider name (``/csp``)
-    :param certificate_key_container: key container name (``/kc``)
+    :param config: signing configuration
     :return: True if signing succeeded, False if skipped or failed
     """
     if file_path is None:
         log.debug("file_path is None; skipping signing")
         return False
 
-    token_mode = is_token_signing_configured(certificate_sha1, certificate_subject, certificate_auto_select)
-    pfx_mode = pfx_path is not None
-
-    if pfx_mode and token_mode:
+    if config.pfx_mode and config.token_mode:
         log.error("both PFX and hardware token signing configured; use only one mode")
         return False
 
-    if token_mode:
-        if certificate_password is None:
+    if config.token_mode:
+        if config.certificate_password is None:
             log.debug("token PIN not provided; hardware token may prompt for PIN interactively")
-        return sign_file_token(
-            file_path,
-            timestamp_url,
-            certificate_sha1=certificate_sha1,
-            certificate_subject=certificate_subject,
-            certificate_auto_select=certificate_auto_select,
-            token_pin=certificate_password,
-            certificate_csp=certificate_csp,
-            certificate_key_container=certificate_key_container,
-            signtool_path=signtool_path,
-        )
+        return sign_file_token(file_path, config)
 
-    if pfx_path is not None:
-        if certificate_password is None:
+    if config.pfx_mode:
+        if config.certificate_password is None:
             log.warning("pfx_path is set but certificate_password not configured; skipping signing")
             return False
-        return sign_file(file_path, pfx_path, certificate_password, timestamp_url, signtool_path)
+        return sign_file(file_path, config)
 
     log.warning("no signing configuration provided; skipping signing")
     return False

--- a/test_pyship/test_b_signing.py
+++ b/test_pyship/test_b_signing.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from pyship.signing import (
+    SigningConfig,
     _find_signtool,
     _resolve_signtool,
     _run_signtool,
@@ -137,20 +138,43 @@ def test_validate_sha1_non_hex():
 
 
 # ---------------------------------------------------------------------------
+# SigningConfig mode properties
+# ---------------------------------------------------------------------------
+
+
+def test_signing_config_no_mode_by_default():
+    config = SigningConfig()
+    assert config.pfx_mode is False
+    assert config.token_mode is False
+
+
+def test_signing_config_pfx_mode(pfx_file):
+    config = SigningConfig(pfx_path=pfx_file)
+    assert config.pfx_mode is True
+    assert config.token_mode is False
+
+
+def test_signing_config_token_mode_each_selector():
+    assert SigningConfig(certificate_sha1=VALID_SHA1).token_mode is True
+    assert SigningConfig(certificate_subject="My Co").token_mode is True
+    assert SigningConfig(certificate_auto_select=True).token_mode is True
+
+
+# ---------------------------------------------------------------------------
 # sign_if_configured — PFX skip tests
 # ---------------------------------------------------------------------------
 
 
 def test_sign_if_configured_skips_when_file_path_none(pfx_file):
-    assert sign_if_configured(None, pfx_file, "password", TIMESTAMP_URL) is False
+    assert sign_if_configured(None, SigningConfig(pfx_path=pfx_file, certificate_password="password", timestamp_url=TIMESTAMP_URL)) is False
 
 
 def test_sign_if_configured_skips_when_pfx_path_none(target_exe):
-    assert sign_if_configured(target_exe, None, "password", TIMESTAMP_URL) is False
+    assert sign_if_configured(target_exe, SigningConfig(certificate_password="password", timestamp_url=TIMESTAMP_URL)) is False
 
 
 def test_sign_if_configured_skips_when_password_none(target_exe, pfx_file):
-    assert sign_if_configured(target_exe, pfx_file, None, TIMESTAMP_URL) is False
+    assert sign_if_configured(target_exe, SigningConfig(pfx_path=pfx_file, timestamp_url=TIMESTAMP_URL)) is False
 
 
 # ---------------------------------------------------------------------------
@@ -160,20 +184,28 @@ def test_sign_if_configured_skips_when_password_none(target_exe, pfx_file):
 
 def test_sign_file_returns_false_when_signtool_not_found(target_exe, pfx_file):
     with patch("pyship.signing._find_signtool", return_value=None):
-        assert sign_file(target_exe, pfx_file, "password", TIMESTAMP_URL) is False
+        assert sign_file(target_exe, SigningConfig(pfx_path=pfx_file, certificate_password="password", timestamp_url=TIMESTAMP_URL)) is False
 
 
 def test_sign_file_returns_false_when_file_missing(tmp_path, pfx_file, signtool_exe):
-    assert sign_file(tmp_path / "missing.exe", pfx_file, "password", TIMESTAMP_URL, signtool_path=signtool_exe) is False
+    config = SigningConfig(pfx_path=pfx_file, certificate_password="password", timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
+    assert sign_file(tmp_path / "missing.exe", config) is False
 
 
 def test_sign_file_returns_false_when_pfx_missing(target_exe, tmp_path, signtool_exe):
-    assert sign_file(target_exe, tmp_path / "missing.pfx", "password", TIMESTAMP_URL, signtool_path=signtool_exe) is False
+    config = SigningConfig(pfx_path=tmp_path / "missing.pfx", certificate_password="password", timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
+    assert sign_file(target_exe, config) is False
+
+
+def test_sign_file_returns_false_when_password_missing(target_exe, pfx_file, signtool_exe):
+    config = SigningConfig(pfx_path=pfx_file, timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
+    assert sign_file(target_exe, config) is False
 
 
 def test_sign_file_calls_subprocess_with_correct_args(target_exe, pfx_file, signtool_exe):
+    config = SigningConfig(pfx_path=pfx_file, certificate_password="secret", signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)) as mock_run:
-        assert sign_file(target_exe, pfx_file, "secret", "http://timestamp.digicert.com", signtool_path=signtool_exe) is True
+        assert sign_file(target_exe, config) is True
 
     cmd = mock_run.call_args[0][0]
     assert "/f" in cmd
@@ -187,13 +219,15 @@ def test_sign_file_calls_subprocess_with_correct_args(target_exe, pfx_file, sign
 
 
 def test_sign_file_returns_false_on_nonzero_return_code(target_exe, pfx_file, signtool_exe):
+    config = SigningConfig(pfx_path=pfx_file, certificate_password="password", timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(1, None, None)):
-        assert sign_file(target_exe, pfx_file, "password", TIMESTAMP_URL, signtool_path=signtool_exe) is False
+        assert sign_file(target_exe, config) is False
 
 
 def test_sign_file_returns_true_on_success(target_exe, pfx_file, signtool_exe):
+    config = SigningConfig(pfx_path=pfx_file, certificate_password="password", timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)):
-        assert sign_file(target_exe, pfx_file, "password", TIMESTAMP_URL, signtool_path=signtool_exe) is True
+        assert sign_file(target_exe, config) is True
 
 
 # ---------------------------------------------------------------------------
@@ -297,11 +331,11 @@ def test_is_certificate_in_store_returns_false_on_exception():
 
 
 def test_check_signing_available_pfx_exists(pfx_file):
-    assert check_signing_available(pfx_path=pfx_file) is True
+    assert check_signing_available(SigningConfig(pfx_path=pfx_file)) is True
 
 
 def test_check_signing_available_pfx_missing(tmp_path):
-    assert check_signing_available(pfx_path=tmp_path / "missing.pfx") is False
+    assert check_signing_available(SigningConfig(pfx_path=tmp_path / "missing.pfx")) is False
 
 
 def test_check_signing_available_token_mode_both_checks_pass():
@@ -310,12 +344,12 @@ def test_check_signing_available_token_mode_both_checks_pass():
         patch("pyship.signing.is_token_present", return_value=True),
         patch("pyship.signing.is_certificate_in_store", return_value=True),
     ):
-        assert check_signing_available(certificate_sha1=VALID_SHA1) is True
+        assert check_signing_available(SigningConfig(certificate_sha1=VALID_SHA1)) is True
 
 
 def test_check_signing_available_token_not_present():
     with patch("pyship.signing.is_rdp_session", return_value=False), patch("pyship.signing.is_token_present", return_value=False):
-        assert check_signing_available(certificate_sha1=VALID_SHA1) is False
+        assert check_signing_available(SigningConfig(certificate_sha1=VALID_SHA1)) is False
 
 
 def test_check_signing_available_token_present_cert_missing():
@@ -324,16 +358,16 @@ def test_check_signing_available_token_present_cert_missing():
         patch("pyship.signing.is_token_present", return_value=True),
         patch("pyship.signing.is_certificate_in_store", return_value=False),
     ):
-        assert check_signing_available(certificate_sha1=VALID_SHA1) is False
+        assert check_signing_available(SigningConfig(certificate_sha1=VALID_SHA1)) is False
 
 
 def test_check_signing_available_auto_select_token_present():
     with patch("pyship.signing.is_rdp_session", return_value=False), patch("pyship.signing.is_token_present", return_value=True):
-        assert check_signing_available(certificate_auto_select=True) is True
+        assert check_signing_available(SigningConfig(certificate_auto_select=True)) is True
 
 
 def test_check_signing_available_nothing_configured():
-    assert check_signing_available() is False
+    assert check_signing_available(SigningConfig()) is False
 
 
 # ---------------------------------------------------------------------------
@@ -384,13 +418,13 @@ def test_is_rdp_session_false_when_all_checks_fail():
 def test_check_signing_available_token_blocked_by_rdp():
     """Token mode should be blocked when RDP session is detected."""
     with patch("pyship.signing.is_rdp_session", return_value=True):
-        assert check_signing_available(certificate_sha1=VALID_SHA1) is False
+        assert check_signing_available(SigningConfig(certificate_sha1=VALID_SHA1)) is False
 
 
 def test_check_signing_available_pfx_not_blocked_by_rdp(pfx_file):
     """PFX mode should NOT be blocked by RDP — PFX signing works fine over RDP."""
     with patch("pyship.signing.is_rdp_session", return_value=True):
-        assert check_signing_available(pfx_path=pfx_file) is True
+        assert check_signing_available(SigningConfig(pfx_path=pfx_file)) is True
 
 
 def test_check_signing_available_token_allowed_when_not_rdp():
@@ -400,7 +434,7 @@ def test_check_signing_available_token_allowed_when_not_rdp():
         patch("pyship.signing.is_token_present", return_value=True),
         patch("pyship.signing.is_certificate_in_store", return_value=True),
     ):
-        assert check_signing_available(certificate_sha1=VALID_SHA1) is True
+        assert check_signing_available(SigningConfig(certificate_sha1=VALID_SHA1)) is True
 
 
 # ---------------------------------------------------------------------------
@@ -410,17 +444,19 @@ def test_check_signing_available_token_allowed_when_not_rdp():
 
 def test_sign_file_token_returns_false_when_signtool_not_found(target_exe):
     with patch("pyship.signing._find_signtool", return_value=None):
-        assert sign_file_token(target_exe, TIMESTAMP_URL, certificate_sha1=VALID_SHA1) is False
+        assert sign_file_token(target_exe, SigningConfig(certificate_sha1=VALID_SHA1, timestamp_url=TIMESTAMP_URL)) is False
 
 
 def test_sign_file_token_returns_false_when_file_missing(tmp_path, signtool_exe):
-    assert sign_file_token(tmp_path / "missing.exe", TIMESTAMP_URL, certificate_sha1=VALID_SHA1, signtool_path=signtool_exe) is False
+    config = SigningConfig(certificate_sha1=VALID_SHA1, timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
+    assert sign_file_token(tmp_path / "missing.exe", config) is False
 
 
 def test_sign_file_token_sha1_builds_correct_command(target_exe, signtool_exe):
     thumbprint = "AABB" * 10
+    config = SigningConfig(certificate_sha1=thumbprint, signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)) as mock_run:
-        assert sign_file_token(target_exe, "http://timestamp.digicert.com", certificate_sha1=thumbprint, signtool_path=signtool_exe) is True
+        assert sign_file_token(target_exe, config) is True
 
     cmd = mock_run.call_args[0][0]
     assert "/sha1" in cmd
@@ -432,8 +468,9 @@ def test_sign_file_token_sha1_builds_correct_command(target_exe, signtool_exe):
 
 
 def test_sign_file_token_subject_builds_correct_command(target_exe, signtool_exe):
+    config = SigningConfig(certificate_subject="My Company", signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)) as mock_run:
-        assert sign_file_token(target_exe, "http://timestamp.digicert.com", certificate_subject="My Company", signtool_path=signtool_exe) is True
+        assert sign_file_token(target_exe, config) is True
 
     cmd = mock_run.call_args[0][0]
     assert "/n" in cmd
@@ -443,8 +480,9 @@ def test_sign_file_token_subject_builds_correct_command(target_exe, signtool_exe
 
 
 def test_sign_file_token_auto_select_builds_correct_command(target_exe, signtool_exe):
+    config = SigningConfig(certificate_auto_select=True, signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)) as mock_run:
-        assert sign_file_token(target_exe, "http://timestamp.digicert.com", certificate_auto_select=True, signtool_path=signtool_exe) is True
+        assert sign_file_token(target_exe, config) is True
 
     cmd = mock_run.call_args[0][0]
     assert "/a" in cmd
@@ -454,8 +492,9 @@ def test_sign_file_token_auto_select_builds_correct_command(target_exe, signtool
 
 
 def test_sign_file_token_with_pin_includes_p_flag(target_exe, signtool_exe):
+    config = SigningConfig(certificate_sha1=VALID_SHA1, certificate_password="123456", signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)) as mock_run:
-        sign_file_token(target_exe, "http://timestamp.digicert.com", certificate_sha1=VALID_SHA1, token_pin="123456", signtool_path=signtool_exe)
+        sign_file_token(target_exe, config)
 
     cmd = mock_run.call_args[0][0]
     assert "/p" in cmd
@@ -463,22 +502,22 @@ def test_sign_file_token_with_pin_includes_p_flag(target_exe, signtool_exe):
 
 
 def test_sign_file_token_without_pin_excludes_p_flag(target_exe, signtool_exe):
+    config = SigningConfig(certificate_sha1=VALID_SHA1, signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)) as mock_run:
-        sign_file_token(target_exe, "http://timestamp.digicert.com", certificate_sha1=VALID_SHA1, signtool_path=signtool_exe)
+        sign_file_token(target_exe, config)
 
     assert "/p" not in mock_run.call_args[0][0]
 
 
 def test_sign_file_token_with_csp_and_kc(target_exe, signtool_exe):
+    config = SigningConfig(
+        certificate_sha1=VALID_SHA1,
+        certificate_csp="eToken Base Cryptographic Provider",
+        certificate_key_container="my-container",
+        signtool_path=signtool_exe,
+    )
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)) as mock_run:
-        sign_file_token(
-            target_exe,
-            "http://timestamp.digicert.com",
-            certificate_sha1=VALID_SHA1,
-            certificate_csp="eToken Base Cryptographic Provider",
-            certificate_key_container="my-container",
-            signtool_path=signtool_exe,
-        )
+        sign_file_token(target_exe, config)
 
     cmd = mock_run.call_args[0][0]
     assert "/csp" in cmd
@@ -488,29 +527,32 @@ def test_sign_file_token_with_csp_and_kc(target_exe, signtool_exe):
 
 
 def test_sign_file_token_invalid_sha1_returns_false(target_exe, signtool_exe):
-    assert sign_file_token(target_exe, TIMESTAMP_URL, certificate_sha1="not_hex", signtool_path=signtool_exe) is False
+    assert sign_file_token(target_exe, SigningConfig(certificate_sha1="not_hex", timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)) is False
 
 
 def test_sign_file_token_short_sha1_returns_false(target_exe, signtool_exe):
-    assert sign_file_token(target_exe, TIMESTAMP_URL, certificate_sha1="aabb", signtool_path=signtool_exe) is False
+    assert sign_file_token(target_exe, SigningConfig(certificate_sha1="aabb", timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)) is False
 
 
 def test_sign_file_token_multiple_selectors_returns_false(target_exe, signtool_exe):
-    assert sign_file_token(target_exe, TIMESTAMP_URL, certificate_sha1=VALID_SHA1, certificate_subject="My Co", signtool_path=signtool_exe) is False
+    config = SigningConfig(certificate_sha1=VALID_SHA1, certificate_subject="My Co", timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
+    assert sign_file_token(target_exe, config) is False
 
 
 def test_sign_file_token_no_selector_returns_false(target_exe, signtool_exe):
-    assert sign_file_token(target_exe, TIMESTAMP_URL, signtool_path=signtool_exe) is False
+    assert sign_file_token(target_exe, SigningConfig(timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)) is False
 
 
 def test_sign_file_token_returns_true_on_success(target_exe, signtool_exe):
+    config = SigningConfig(certificate_sha1=VALID_SHA1, timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(0, None, None)):
-        assert sign_file_token(target_exe, TIMESTAMP_URL, certificate_sha1=VALID_SHA1, signtool_path=signtool_exe) is True
+        assert sign_file_token(target_exe, config) is True
 
 
 def test_sign_file_token_returns_false_on_nonzero_return_code(target_exe, signtool_exe):
+    config = SigningConfig(certificate_sha1=VALID_SHA1, timestamp_url=TIMESTAMP_URL, signtool_path=signtool_exe)
     with patch("pyship.signing.subprocess_run", return_value=(1, None, None)):
-        assert sign_file_token(target_exe, TIMESTAMP_URL, certificate_sha1=VALID_SHA1, signtool_path=signtool_exe) is False
+        assert sign_file_token(target_exe, config) is False
 
 
 # ---------------------------------------------------------------------------
@@ -519,41 +561,48 @@ def test_sign_file_token_returns_false_on_nonzero_return_code(target_exe, signto
 
 
 def test_sign_if_configured_dispatches_to_token_mode_sha1(target_exe):
+    config = SigningConfig(certificate_sha1=VALID_SHA1, certificate_password="pin123", timestamp_url=TIMESTAMP_URL)
     with patch("pyship.signing.sign_file_token", return_value=True) as mock_token:
-        assert sign_if_configured(target_exe, None, "pin123", TIMESTAMP_URL, certificate_sha1=VALID_SHA1) is True
+        assert sign_if_configured(target_exe, config) is True
 
     mock_token.assert_called_once()
-    assert mock_token.call_args.kwargs["certificate_sha1"] == VALID_SHA1
-    assert mock_token.call_args.kwargs["token_pin"] == "pin123"
+    passed_config = mock_token.call_args[0][1]
+    assert passed_config.certificate_sha1 == VALID_SHA1
+    assert passed_config.certificate_password == "pin123"
 
 
 def test_sign_if_configured_dispatches_to_token_mode_subject(target_exe):
+    config = SigningConfig(certificate_subject="My Company", timestamp_url=TIMESTAMP_URL)
     with patch("pyship.signing.sign_file_token", return_value=True) as mock_token:
-        assert sign_if_configured(target_exe, None, None, TIMESTAMP_URL, certificate_subject="My Company") is True
+        assert sign_if_configured(target_exe, config) is True
 
     mock_token.assert_called_once()
-    assert mock_token.call_args.kwargs["certificate_subject"] == "My Company"
-    assert mock_token.call_args.kwargs["token_pin"] is None
+    passed_config = mock_token.call_args[0][1]
+    assert passed_config.certificate_subject == "My Company"
+    assert passed_config.certificate_password is None
 
 
 def test_sign_if_configured_dispatches_to_token_mode_auto(target_exe):
+    config = SigningConfig(certificate_auto_select=True, timestamp_url=TIMESTAMP_URL)
     with patch("pyship.signing.sign_file_token", return_value=True) as mock_token:
-        assert sign_if_configured(target_exe, None, None, TIMESTAMP_URL, certificate_auto_select=True) is True
+        assert sign_if_configured(target_exe, config) is True
 
     mock_token.assert_called_once()
-    assert mock_token.call_args.kwargs["certificate_auto_select"] is True
+    assert mock_token.call_args[0][1].certificate_auto_select is True
 
 
 def test_sign_if_configured_returns_false_when_both_modes_configured(target_exe, pfx_file):
-    assert sign_if_configured(target_exe, pfx_file, "password", TIMESTAMP_URL, certificate_sha1=VALID_SHA1) is False
+    config = SigningConfig(pfx_path=pfx_file, certificate_password="password", certificate_sha1=VALID_SHA1, timestamp_url=TIMESTAMP_URL)
+    assert sign_if_configured(target_exe, config) is False
 
 
 def test_sign_if_configured_token_mode_without_pin(target_exe):
+    config = SigningConfig(certificate_sha1=VALID_SHA1, timestamp_url=TIMESTAMP_URL)
     with patch("pyship.signing.sign_file_token", return_value=True) as mock_token:
-        assert sign_if_configured(target_exe, None, None, TIMESTAMP_URL, certificate_sha1=VALID_SHA1) is True
+        assert sign_if_configured(target_exe, config) is True
 
-    assert mock_token.call_args.kwargs["token_pin"] is None
+    assert mock_token.call_args[0][1].certificate_password is None
 
 
 def test_sign_if_configured_no_signing_configured(target_exe):
-    assert sign_if_configured(target_exe, None, None, TIMESTAMP_URL) is False
+    assert sign_if_configured(target_exe, SigningConfig(timestamp_url=TIMESTAMP_URL)) is False

--- a/test_pyship/test_b_signing_coverage.py
+++ b/test_pyship/test_b_signing_coverage.py
@@ -7,7 +7,7 @@ from argparse import Namespace
 
 import pytest
 
-from pyship.signing import is_certificate_in_store, sign_if_configured
+from pyship.signing import SigningConfig, is_certificate_in_store, sign_if_configured
 from pyship.pyship import PyShip, SIGNING_PIN_ENV_VAR
 from pyship.exceptions import PyshipSigningUnavailable
 from pyship.main import read_pyship_config
@@ -56,7 +56,7 @@ def test_sign_if_configured_pfx_mode_calls_sign_file(tmp_path):
     pfx.touch()
 
     with patch("pyship.signing.sign_file", return_value=True) as mock_sign:
-        result = sign_if_configured(target, pfx, "secret", "http://ts.example.com")
+        result = sign_if_configured(target, SigningConfig(pfx_path=pfx, certificate_password="secret", timestamp_url="http://ts.example.com"))
 
     assert result is True
     mock_sign.assert_called_once()
@@ -100,7 +100,7 @@ def test_sign_or_raise_succeeds(tmp_path):
     ps = PyShip()
 
     with patch("pyship.pyship.sign_if_configured", return_value=True):
-        ps._sign_or_raise(target, "password")  # should not raise
+        ps._sign_or_raise(target, ps._signing_config())  # should not raise
 
 
 def test_sign_or_raise_raises_on_failure(tmp_path):
@@ -111,7 +111,33 @@ def test_sign_or_raise_raises_on_failure(tmp_path):
 
     with patch("pyship.pyship.sign_if_configured", return_value=False):
         with pytest.raises(PyshipSigningUnavailable):
-            ps._sign_or_raise(target, "password")
+            ps._sign_or_raise(target, ps._signing_config())
+
+
+# ---------------------------------------------------------------------------
+# pyship.py — _signing_config
+# ---------------------------------------------------------------------------
+
+
+def test_signing_config_collects_pyship_fields(monkeypatch):
+    """_signing_config should mirror the flat PyShip fields, with the password resolved."""
+    monkeypatch.delenv(SIGNING_PIN_ENV_VAR, raising=False)
+    ps = PyShip(pfx_path=Path("cert.pfx"), certificate_password="secret", certificate_csp="csp-name")
+    config = ps._signing_config()
+    assert config.pfx_path == Path("cert.pfx")
+    assert config.certificate_password == "secret"
+    assert config.certificate_csp == "csp-name"
+    assert config.pfx_mode is True
+    assert config.token_mode is False
+
+
+def test_signing_config_resolves_password_from_env(monkeypatch):
+    """_signing_config should fall back to the PIN environment variable."""
+    monkeypatch.setenv(SIGNING_PIN_ENV_VAR, "env_pin")
+    ps = PyShip(certificate_sha1="aa" * 20)
+    config = ps._signing_config()
+    assert config.certificate_password == "env_pin"
+    assert config.token_mode is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `sign_if_configured` took 10 parameters, mirrored by `PyShip._sign_or_raise` and `check_signing_available` — every new signing option meant threading a parameter through four signatures.
- New `SigningConfig` dataclass in `signing.py` holds all signing settings, with `pfx_mode` / `token_mode` properties (absorbing the `is_token_signing_configured` helper added in #44).
- `sign_file`, `sign_file_token`, `sign_if_configured`, and `check_signing_available` now take the config object.
- **`PyShip`'s user-facing API is unchanged**: the flat fields stay because they mirror the `[tool.pyship]` / CLI configuration surface (all README examples remain valid). `ship()` builds the config once via `_signing_config()`, resolving the password/PIN from `PYSHIP_SIGNING_CERTIFICATE_PIN` at that point.
- `DEFAULT_TIMESTAMP_URL` constant shared by `SigningConfig` and `PyShip`.

## API changes
- Signing function signatures changed (config object instead of flat params).
- Exported: `SigningConfig`, `DEFAULT_TIMESTAMP_URL`. Removed: `is_token_signing_configured` (introduced earlier today in #44/0.7.4; superseded by `SigningConfig.token_mode`).

## Test plan
- [x] All signing tests updated to the new signatures; 6 new tests (SigningConfig mode properties, missing-PFX-password path, `_signing_config` field collection and env fallback)
- [x] `ruff` / `ty` clean, 237 fast unit tests pass locally
- [ ] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)