### PR TITLE
Bump version to 0.7.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyship"
-version = "0.7.4"
+version = "0.7.5"
 description = "freezer, installer and updater for Python applications"
 readme = "readme.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Version bump for the 0.7.5 release:
- SigningConfig dataclass replaces flat signing parameters (#48)
- lazy tkinter import — pyship now imports in headless environments (#46)
- subprocess_run logs env var names only, not values (#47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)